### PR TITLE
Add the Lost Woods Bridge region

### DIFF
--- a/data/oot/pool.csv
+++ b/data/oot/pool.csv
@@ -11,7 +11,7 @@ Kokiri Forest GS Night Adult,         gs,             KOKIRI_FOREST,            
 Malon Egg,                            npc,            HYRULE_CASTLE,            MALON_EGG,                  CHICKEN
 Zelda's Letter,                       npc,            CASTLE_COURTYARD,         ZELDA_LETTER,               ZELDA_LETTER
 Zelda's Song,                         npc,            CASTLE_COURTYARD,         ZELDA_SONG,                 SONG_ZELDA
-Lost Woods Bridge,                    npc,            LOST_WOODS,               SARIA_OCARINA,              OCARINA
+Saria's Gift,                         npc,            LOST_WOODS,               SARIA_OCARINA,              OCARINA
 Lost Woods Target,                    npc,            LOST_WOODS,               LOST_WOODS_TARGET,          SLINGSHOT
 Lost Woods Skull Kid,                 npc,            LOST_WOODS,               LOST_WOODS_SKULL_KID,       HEART_PIECE
 Lost Woods Memory Game,               npc,            LOST_WOODS,               LOST_WOODS_MEMORY,          HEART_PIECE

--- a/data/oot/world/overworld.yml
+++ b/data/oot/world/overworld.yml
@@ -15,6 +15,7 @@
     "Link's House": "true"
     "Mido's House": "true"
     "Lost Woods": "true"
+    "Lost Woods Bridge": "true"
     "Deku Tree Lobby": "is_child"
   locations:
     "Kokiri Forest Kokiri Sword Chest": "is_child"
@@ -32,7 +33,7 @@
     "Kokiri Forest Mido Bottom Right": "true"
 "Hyrule Field":
   exits:
-    "Lost Woods": "true"
+    "Lost Woods Bridge": "true"
     "Market": "is_child"
     "Market Destroyed": "is_adult"
     "Kakariko": "true"
@@ -150,12 +151,11 @@
 "Lost Woods":
   exits:
     "Kokiri Forest": "true"
-    "Hyrule Field": "true"
+    "Lost Woods Bridge": "can_longshot || has_hover_boots || (can_use_beans && is_adult)
     "Lost Woods Deep": "is_child || can_play(SONG_SARIA)"
     "Goron City Shortcut": "true"
     "Zora River": "can_dive_small"
   locations:
-    "Lost Woods Bridge": "true"
     "Lost Woods Target": "can_use_slingshot"
     "Lost Woods Skull Kid": "is_child && can_play(SONG_SARIA)"
     "Lost Woods Memory Game": "is_child && has(OCARINA)"
@@ -164,6 +164,13 @@
     "Lost Woods Poacher's Saw": "is_adult && has(ODD_POTION)"
     "Lost Woods Grotto Generic": "has_explosives"
     "Lost Woods GS Soil Bridge": "gs_soil"
+"Lost Woods Bridge":
+  exits:
+    "Kokiri Forest": "true"
+    "Hyrule Field": "true"
+    "Lost Woods": "can_longshot"
+  locations:
+    "Saria's Gift": "true"
 "Lost Woods Deep":
   exits:
     "Lost Woods": "is_child || can_play(SONG_SARIA)"


### PR DESCRIPTION
- Separates the bridge in Lost Woods into its own region, including the two exits and single check
- Adds exits to go to and from the bridge and lost woods itself
- Renames the location to Saria's Gift for parity with OOTR