### PR TITLE
OoTR logic compliance part 2

### DIFF
--- a/data/oot/world/dodongo_cavern.yml
+++ b/data/oot/world/dodongo_cavern.yml
@@ -2,7 +2,7 @@
   dungeon: DC
   exits:
     "Death Mountain": "true"
-    "Dodongo Cavern Main": "has_bombflowers"
+    "Dodongo Cavern Main": "has_bombflowers || can_hammer"
 "Dodongo Cavern Main":
   dungeon: DC
   exits:
@@ -12,7 +12,7 @@
     "Dodongo Cavern Stairs": "event(DC_MAIN_SWITCH)"
     "Dodongo Cavern Skull": "event(DC_BOMB_EYES)"
   locations:
-    "Dodongo Cavern Map Chest": "has_bombflowers"
+    "Dodongo Cavern Map Chest": "has_bombflowers || can_hammer"
 "Dodongo Cavern Right Corridor":
   dungeon: DC
   exits:
@@ -31,7 +31,7 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Right Corridor": "true"
-    "Dodongo Cavern Green Room": "has_weapon"
+    "Dodongo Cavern Green Room": "true"
 "Dodongo Cavern Green Room":
   dungeon: DC
   exits:
@@ -48,14 +48,14 @@
   exits:
     "Dodongo Cavern Main": "true"
     "Dodongo Cavern Compass Room": "true"
-    "Dodongo Cavern Stairs Top": "has_bombflowers"
+    "Dodongo Cavern Stairs Top": "has_bombflowers || can_use_din"
 "Dodongo Cavern Stairs Top":
   dungeon: DC
   exits:
     "Dodongo Cavern Stairs": "true"
     "Dodongo Cavern Bomb Bag Room 1": "true"
   locations:
-    "Dodongo Cavern GS Stairs Vines": "has_ranged_weapon"
+    "Dodongo Cavern GS Stairs Vines": "true"
     "Dodongo Cavern GS Stairs Top": "can_hookshot || can_boomerang"
 "Dodongo Cavern Compass Room":
   dungeon: DC
@@ -67,6 +67,7 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Stairs Top": "true"
+    "Dodongo Cavern Bomb Bag Room 2": "can_longshot || has_hover_boots"
     "Dodongo Cavern Miniboss 2": "can_hit_triggers_distance"
   locations:
     "Dodongo Cavern Bomb Bag Side Chest": "true"
@@ -74,11 +75,12 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Bomb Bag Room 1": "true"
-    "Dodongo Cavern Bomb Bag Room 2": "can_hit_triggers_distance && has_weapon"
+    "Dodongo Cavern Bomb Bag Room 2": "can_hit_triggers_distance"
 "Dodongo Cavern Bomb Bag Room 2":
   dungeon: DC
   exits:
     "Dodongo Cavern Miniboss 2": "true"
+    "Dodongo Cavern Bomb Bag Room 1": "true"
     "Dodongo Cavern Main Bridge": "true"
   locations:
     "Dodongo Cavern Bomb Bag Chest": "true"
@@ -88,9 +90,9 @@
     "Dodongo Cavern Bomb Bag Room 2": "true"
   events:
     DC_SHORTCUT: "true"
-    DC_BOMB_EYES: "has(BOMB_BAG)"
+    DC_BOMB_EYES: "has_explosives"
   locations:
-    "Dodongo Cavern Bridge Chest": "has_explosives"
+    "Dodongo Cavern Bridge Chest": "has_explosives_or_hammer"
 "Dodongo Cavern Skull":
   dungeon: DC
   exits:

--- a/data/oot/world/gerudo_fortress.yml
+++ b/data/oot/world/gerudo_fortress.yml
@@ -8,6 +8,6 @@
     "Gerudo Fortress Jail 1": "true"
     "Gerudo Fortress Jail 2": "true"
     "Gerudo Fortress Jail 3": "true"
-    "Gerudo Fortress Jail 4": "true"
+    "Gerudo Fortress Jail 4": "can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD)"
     "Gerudo Member Card": "event(CARPENTERS_RESCUE)"
 

--- a/data/oot/world/gerudo_training_grounds.yml
+++ b/data/oot/world/gerudo_training_grounds.yml
@@ -2,17 +2,17 @@
   dungeon: GTG
   exits:
     "Gerudo Fortress": "true"
-    "Gerudo Training Grounds Left Side": "can_hookshot"
-    "Gerudo Training Grounds Right Side": "has_explosives"
+    "Gerudo Training Grounds Left Side": "can_hookshot && has_weapon"
+    "Gerudo Training Grounds Right Side": "has_explosives && has_weapon"
     "Gerudo Training Grounds Maze": "true"
   locations:
     "Gerudo Training Grounds Entrance 1": "can_use_bow || can_use_slingshot"
     "Gerudo Training Grounds Entrance 2": "can_use_bow || can_use_slingshot"
-    "Gerudo Training Grounds Stalfos": "true"
+    "Gerudo Training Grounds Stalfos": "has_weapon"
 "Gerudo Training Grounds Left Side":
   dungeon: GTG
   exits:
-    "Gerudo Training Grounds After Block": "is_adult && has(STRENGTH, 2)"
+    "Gerudo Training Grounds After Block": "can_lift_silver && has_lens && can_hookshot"
     "Gerudo Training Grounds Upper": "can_hookshot && has_lens"
   locations:
     "Gerudo Training Grounds Near Block": "true"
@@ -40,8 +40,8 @@
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Maze Side": "can_play(SONG_TIME)"
-    "Gerudo Training Grounds Hammer": "can_longshot && has(BOOTS_HOVER)"
-    "Gerudo Training Grounds Water": "can_longshot && has(BOOTS_HOVER)"
+    "Gerudo Training Grounds Hammer": "can_hookshot && (has_hover_boots || can_play(SONG_TIME))"
+    "Gerudo Training Grounds Water": "can_hookshot && (has_hover_boots || can_play(SONG_TIME))"
 "Gerudo Training Grounds Maze Side":
   dungeon: GTG
   locations:
@@ -51,26 +51,25 @@
 "Gerudo Training Grounds Water":
   dungeon: GTG
   locations:
-    "Gerudo Training Water": "is_adult && can_play(SONG_TIME) && has(TUNIC_ZORA) && has(BOOTS_IRON) && has(HOOKSHOT)"
+    "Gerudo Training Water": "can_play(SONG_TIME) && has_tunic_zora && has_iron_boots"
 "Gerudo Training Grounds Hammer":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Lava": "true"
-    "Gerudo Training Grounds Statue": "is_adult && has(HAMMER) && has(BOW)"
+    "Gerudo Training Grounds Statue": "can_hammer && can_use_bow"
   locations:
-    "Gerudo Training Grounds Hammer Room Switch": "is_adult && has(HAMMER)"
+    "Gerudo Training Grounds Hammer Room Switch": "can_hammer"
     "Gerudo Training Grounds Hammer Room": "true"
 "Gerudo Training Grounds Statue":
   dungeon: GTG
   exits:
-    "Gerudo Training Grounds Upper": "scarecrow_hookshot"
     "Gerudo Training Grounds Hammer": "true"
   locations:
-    "Gerudo Training Grounds Eye Statue": "true"
+    "Gerudo Training Grounds Eye Statue": "can_use_bow"
 "Gerudo Training Grounds Maze":
   dungeon: GTG
   locations:
-    "Gerudo Training Maze Upper Fake Ceiling": "has(SMALL_KEY_GTG, 3)"
+    "Gerudo Training Maze Upper Fake Ceiling": "has(SMALL_KEY_GTG, 3) && has_lens"
     "Gerudo Training Maze Chest 1": "has(SMALL_KEY_GTG, 4)"
     "Gerudo Training Maze Chest 2": "has(SMALL_KEY_GTG, 6)"
     "Gerudo Training Maze Chest 3": "has(SMALL_KEY_GTG, 7)"

--- a/data/oot/world/gerudo_training_grounds.yml
+++ b/data/oot/world/gerudo_training_grounds.yml
@@ -40,7 +40,7 @@
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Maze Side": "can_play(SONG_TIME)"
-    "Gerudo Training Grounds Hammer": "can_hookshot && (has_hover_boots || can_play(SONG_TIME))"
+    "Gerudo Training Grounds Hammer": "can_hookshot && (can_longshot || has_hover_boots || can_play(SONG_TIME))"
     "Gerudo Training Grounds Water": "can_hookshot && (has_hover_boots || can_play(SONG_TIME))"
 "Gerudo Training Grounds Maze Side":
   dungeon: GTG

--- a/data/oot/world/jabu_jabu.yml
+++ b/data/oot/world/jabu_jabu.yml
@@ -2,7 +2,7 @@
   dungeon: JJ
   exits:
     "Zora Fountain": "true"
-    "Jabu-Jabu Main": "has_ranged_weapon"
+    "Jabu-Jabu Main": "has_ranged_weapon || has_explosives"
 "Jabu-Jabu Main":
   dungeon: JJ
   exits:
@@ -14,7 +14,7 @@
     "Jabu-Jabu Boomerang Chest": "true"
     "Jabu-Jabu GS Bottom Lower": "can_boomerang"
     "Jabu-Jabu GS Bottom Upper": "can_boomerang"
-    "Jabu-Jabu GS Water Switch": "has_ranged_weapon"
+    "Jabu-Jabu GS Water Switch": "has_ranged_weapon || has_explosives"
     "Jabu-Jabu GS Near Boss": "can_boomerang"
 "Jabu-Jabu Boss":
   dungeon: JJ


### PR DESCRIPTION
This should bring Dodongo's Cavern, Jabu Jabu's Belly, Gerudo Fortress, and GTG into logical harmony with OoTR. A few minor logic bugs that could have possibly made broken seeds are fixed too (but all were pretty low probability issues), mostly it's making a few things less restrictive. This should also be construed as to include Deku Tree, Bottom of the Well, and Ice Cavern, but those three dungeons were perfect as-is so there is no file being changed.