### PR TITLE
Improve logic for Ikana Castle and Beneath the Well

### DIFF
--- a/data/mm/macros.yml
+++ b/data/mm/macros.yml
@@ -24,3 +24,4 @@
 "can_fight": "has_weapon || has(MASK_ZORA) || has(MASK_GORON)"
 "can_lullaby": "has(OCARINA) && has(SONG_GORON_HALF, 2) && has(MASK_GORON)"
 "has_shield": "true"
+"can_activate_crystal": "can_break_boulders || has_weapon || has(BOW) || has(HOOKSHOT) || has(MASK_DEKU) || has(MASK_ZORA)"

--- a/data/mm/world/ancient_castle_of_ikana.yml
+++ b/data/mm/world/ancient_castle_of_ikana.yml
@@ -46,11 +46,12 @@
 "Ancient Castle of Ikana Wizzrobe":
   region: IKANA_CASTLE
   exits:
-    "Ancient Castle of Ikana Interior South": "can_fight || has(BOW)"
+    "Ancient Castle of Ikana Interior South": "can_use_light_arrows"
     "Ancient Castle of Ikana Roof Interior": "can_fight || has(BOW)"
 "Ancient Castle of Ikana Roof Interior":
   region: IKANA_CASTLE
   exits:
+    "Ancient Castle of Ikana Interior": "event(IKANA_CASTLE_LIGHT2)"
     "Ancient Castle of Ikana Wizzrobe": "true"
   events:
     IKANA_CASTLE_LIGHT2: "can_use_keg"

--- a/data/mm/world/ancient_castle_of_ikana.yml
+++ b/data/mm/world/ancient_castle_of_ikana.yml
@@ -1,43 +1,71 @@
 "Ancient Castle of Ikana Exterior":
   region: IKANA_CASTLE
   exits:
-    "Beneath the Well End": "has_mirror_shield || can_use_light_arrows"
-    "Ancient Castle of Ikana Entrance": "true"
+    "Beneath the Well End": "can_use_light_arrows"
+    "Ancient Castle of Ikana Entrance": "can_use_light_arrows"
+    "Ancient Castle of Ikana Interior": "true"
 "Ancient Castle of Ikana Entrance":
   region: IKANA_CASTLE
   exits:
+    "Ancient Castle of Ikana Exterior": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT_ENTRANCE) || can_use_light_arrows"
+    "Ikana Canyon": "true"
+  events:
+    IKANA_CASTLE_LIGHT_ENTRANCE: "can_activate_crystal"
+"Ancient Castle of Ikana Interior":
+  region: IKANA_CASTLE
+  exits:
     "Ancient Castle of Ikana Exterior": "true"
-    "Ikana Canyon": "has_mirror_shield"
     "Ancient Castle of Ikana Interior North": "can_use_fire_arrows"
     "Ancient Castle of Ikana Interior South": "can_use_fire_arrows"
-    "Ancient Castle of Ikana Boss": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT2)) || can_use_light_arrows"
+    "Ancient Castle of Ikana Pre-Boss": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT2)) || can_use_light_arrows"
+    "Ancient Castle of Ikana Interior North 2": "has(MASK_DEKU)"
 "Ancient Castle of Ikana Interior North":
   region: IKANA_CASTLE
   exits:
+    "Ancient Castle of Ikana Interior": "true"
     "Ancient Castle of Ikana Interior North 2": "has(MASK_DEKU)"
 "Ancient Castle of Ikana Interior North 2":
   region: IKANA_CASTLE
   exits:
+    "Ancient Castle of Ikana Interior North": "has(MASK_DEKU)"
     "Ancient Castle of Ikana Roof Exterior": "can_use_lens"
 "Ancient Castle of Ikana Roof Exterior":
   region: IKANA_CASTLE
+  exits:
+    "Ancient Castle of Ikana Interior North 2": "true"
+    "Ancient Castle of Ikana Exterior": "true"
   events:
     IKANA_CASTLE_LIGHT: "has(MASK_DEKU)"
   locations:
-    "Ancient Castle of Ikana HP": "has(BOW) && has(MASK_DEKU)"
+    "Ancient Castle of Ikana HP": "(has(BOW) || has(HOOKSHOT)) && has(MASK_DEKU)"
 "Ancient Castle of Ikana Interior South":
   region: IKANA_CASTLE
   exits:
-    "Ancient Castle of Ikana Roof Interior": "has_mirror_shield && event(IKANA_CASTLE_LIGHT)"
-"Ancient Castle of Ikana Roof Interior":
-  region: IKANA_CASTLE
-  events:
-    IKANA_CASTLE_LIGHT2: "can_use_keg"
-"Ancient Castle of Ikana Boss":
+    "Ancient Castle of Ikana Interior": "true"
+    "Ancient Castle of Ikana Wizzrobe": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT)) || can_use_light_arrows"
+"Ancient Castle of Ikana Wizzrobe":
   region: IKANA_CASTLE
   exits:
-    "Ancient Castle of Ikana After Boss": "has_mirror_shield && can_use_fire_arrows"
+    "Ancient Castle of Ikana Interior South": "can_fight || has(BOW)"
+    "Ancient Castle of Ikana Roof Interior": "can_fight || has(BOW)"
+"Ancient Castle of Ikana Roof Interior":
+  region: IKANA_CASTLE
+  exits:
+    "Ancient Castle of Ikana Wizzrobe": "true"
+  events:
+    IKANA_CASTLE_LIGHT2: "can_use_keg"
+"Ancient Castle of Ikana Pre-Boss":
+  region: IKANA_CASTLE
+  exits:
+    "Ancient Castle of Ikana Interior": "true"
+    "Ancient Castle of Ikana Throne Room": "true"
+"Ancient Castle of Ikana Throne Room":
+  region: IKANA_CASTLE
+  exits:
+    "Ancient Castle of Ikana After Boss": "has_mirror_shield && can_use_fire_arrows && can_fight"
 "Ancient Castle of Ikana After Boss":
   region: IKANA_CASTLE
+  exits:
+    "Ancient Castle of Ikana Pre-Boss": "true"
   locations:
     "Ancient Castle of Ikana Song Emptiness": "true"

--- a/data/mm/world/ancient_castle_of_ikana.yml
+++ b/data/mm/world/ancient_castle_of_ikana.yml
@@ -7,7 +7,7 @@
 "Ancient Castle of Ikana Entrance":
   region: IKANA_CASTLE
   exits:
-    "Ancient Castle of Ikana Exterior": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT_ENTRANCE) || can_use_light_arrows"
+    "Ancient Castle of Ikana Exterior": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT_ENTRANCE)) || can_use_light_arrows"
     "Ikana Canyon": "true"
   events:
     IKANA_CASTLE_LIGHT_ENTRANCE: "can_activate_crystal"

--- a/data/mm/world/beneath_the_well.yml
+++ b/data/mm/world/beneath_the_well.yml
@@ -9,7 +9,7 @@
   exits:
     "Beneath the Well Entrance": "true"
   events:
-    WELL_HOT_WATER: "true"
+    WELL_HOT_WATER: "has_explosives || has(MASK_ZORA)"
   locations:
     "Beneath the Well Keese Chest": "can_use_lens"
 "Beneath the Well East Section":

--- a/data/mm/world/beneath_the_well.yml
+++ b/data/mm/world/beneath_the_well.yml
@@ -6,19 +6,25 @@
     "Beneath the Well East Section": "has(MASK_GIBDO) && has_beans"
 "Beneath the Well North Section":
   region: BENEATH_THE_WELL
+  exits:
+    "Beneath the Well Entrance": "true"
   events:
-    WELL_HOT_WATER: "has(MASK_GIBDO) && event(BLUE_POTION)"
+    WELL_HOT_WATER: "has_explosives || has(MASK_ZORA)"
   locations:
-    "Beneath the Well Keese Chest": "true"
+    "Beneath the Well Keese Chest": "can_use_lens"
 "Beneath the Well East Section":
   region: BENEATH_THE_WELL
-  locations:
-    "Beneath the Well Skulltulla Chest": "has_bottle"
   exits:
-    "Beneath the Well End": "has(MASK_GIBDO) && has(BOMB_BAG)"
+    "Beneath the Well Entrance": "true"
+    "Beneath the Well End": "event(WELL_BIG_POE)"
+  events:
+    WELL_BIG_POE: "has(MASK_GIBDO) && has_bottle && has(BOMB_BAG) && (has(BOW) || has(ZORA))"
+  locations:
+    "Beneath the Well Skulltulla Chest": "has(MASK_GIBDO) && has_bottle"
 "Beneath the Well End":
   region: BENEATH_THE_WELL
   exits:
+    "Beneath the Well East Section": "true"
     "Ancient Castle of Ikana Exterior": "has_mirror_shield || can_use_light_arrows"
   locations:
-    "Beneath the Well Mirror Shield": "true"
+    "Beneath the Well Mirror Shield": "can_use_fire_arrows || event(WELL_BIG_POE)"

--- a/data/mm/world/beneath_the_well.yml
+++ b/data/mm/world/beneath_the_well.yml
@@ -9,7 +9,7 @@
   exits:
     "Beneath the Well Entrance": "true"
   events:
-    WELL_HOT_WATER: "has_explosives || has(MASK_ZORA)"
+    WELL_HOT_WATER: "true"
   locations:
     "Beneath the Well Keese Chest": "can_use_lens"
 "Beneath the Well East Section":

--- a/data/oot/world/fire_temple.yml
+++ b/data/oot/world/fire_temple.yml
@@ -3,49 +3,61 @@ Fire Temple Entrance:
   exits:
     "Death Mountain Crater Bottom": "true"
     "Fire Temple Lava Room": "has(SMALL_KEY_FIRE, 1)"
-    "Fire Temple Boss": "has(BOSS_KEY_FIRE) && event(FIRE_TEMPLE_PILLAR_HAMMER) && can_hammer"
+    "Fire Temple Boss": "has(BOSS_KEY_FIRE) && (event(FIRE_TEMPLE_PILLAR_HAMMER) || has_hover_boots)"
   locations:
     "Fire Temple Jail 1 Chest": "true"
-    "Fire Temple Boss Key Side Chest": "can_hammer && has_explosives && has(HOOKSHOT)"
-    "Fire Temple Boss Key Chest": "can_hammer && has_explosives && has(HOOKSHOT)"
+    "Fire Temple Boss Key Side Chest": "can_hammer"
+    "Fire Temple Boss Key Chest": "can_hammer"
     "Fire Temple GS Hammer Statues": "can_hammer"
 "Fire Temple Lava Room":
   dungeon: Fire
   exits:
-    "Fire Temple After Elevator": "has(SMALL_KEY_FIRE, 3) && (has(BOW) || has(HOOKSHOT) || has_explosives)"
+    "Fire Temple After Elevator": "has(SMALL_KEY_FIRE, 3) && has(STRENGTH) && (has_ranged_weapon_adult || has_explosives)"
   locations:
     "Fire Temple Jail 2 Chest": "true"
-    "Fire Temple Jail 3 Chest": "true"
+    "Fire Temple Jail 3 Chest": "has_explosives"
     "Fire Temple GS Lava Side Room": "can_play(SONG_TIME)"
 "Fire Temple After Elevator":
   dungeon: Fire
   exits:
     "Fire Temple Entrance": "true"
-    "Fire Temple Ring": "has(SMALL_KEY_FIRE, 7) && can_play(SONG_TIME)"
+    "Fire Temple Ring": "has(SMALL_KEY_FIRE, 6)"
     "Fire Temple Scarecrow": "has(SMALL_KEY_FIRE, 5) && scarecrow_hookshot"
   locations:
     "Fire Temple Maze Chest": "true"
     "Fire Temple Jail 4 Chest": "true"
-    "Fire Temple Map": "has(SMALL_KEY_FIRE, 4) && has(BOW)"
+    "Fire Temple Map": "has(SMALL_KEY_FIRE, 4) && (can_use_bow || has(SMALL_KEY_FIRE, 5))"
     "Fire Temple Above Maze Chest": "has(SMALL_KEY_FIRE, 5)"
-    "Fire Temple Below Maze Chest": "has(SMALL_KEY_FIRE, 5) && has_explosives_or_hammer"
+    "Fire Temple Below Maze Chest": "has(SMALL_KEY_FIRE, 5) && has_explosives"
     "Fire Temple GS Maze": "has_explosives"
 "Fire Temple Ring":
   dungeon: Fire
   exits:
     "Fire Temple After Elevator": "true"
-    "Fire Temple After Miniboss": "has_explosives && has(HOOKSHOT)"
+    "Fire Temple Before Miniboss": "has(SMALL_KEY_FIRE, 7)"
+    "Fire Temple Pillar Ledge": "has_hover_boots"
   locations:
     "Fire Temple Compass": "true"
-"Fire Temple After Miniboss":
+"Fire Temple Before Miniboss":
   dungeon: Fire
   exits:
+    "Fire Temple After Miniboss": "has_explosives"
+    "Fire Temple Pillar Ledge": "can_play(SONG_TIME)"
+  locations:
+    "Fire Temple Ring Jail": "can_hammer && can_play(SONG_TIME)"
+"Fire Temple Pillar Ledge":
+  dungeon: Fire
+  exits:
+    "Fire Temple Before Miniboss": "can_hammer"
     "Fire Temple Ring": "true"
   events:
     FIRE_TEMPLE_PILLAR_HAMMER: "can_hammer"
+"Fire Temple After Miniboss":
+  dungeon: Fire
+  exits:
+    "Fire Temple Pillar Ledge": "true"
   locations:
     "Fire Temple Hammer": "true"
-    "Fire Temple Ring Jail": "can_hammer"
 "Fire Temple Boss":
   dungeon: Fire
   exits:
@@ -58,6 +70,6 @@ Fire Temple Entrance:
 "Fire Temple Scarecrow":
   dungeon: Fire
   locations:
-    "Fire Temple Scarecrow Chest": "can_hookshot"
-    "Fire Temple GS Scarecrow Wall": "can_collect_distance"
+    "Fire Temple Scarecrow Chest": "true"
+    "Fire Temple GS Scarecrow Wall": "has_ranged_weapon_adult"
     "Fire Temple GS Scarecrow Top": "can_collect_distance"

--- a/data/oot/world/forest_temple.yml
+++ b/data/oot/world/forest_temple.yml
@@ -4,8 +4,8 @@
     "Sacred Meadow": "true"
     "Forest Temple Main": "true"
   locations:
-    "Forest Temple Tree Small Key": "can_hookshot"
-    "Forest Temple GS Entrance": "can_collect_distance"
+    "Forest Temple Tree Small Key": "true"
+    "Forest Temple GS Entrance": "has_ranged_weapon || has_explosives || can_use_din"
 "Forest Temple Main":
   dungeon: Forest
   exits:
@@ -28,14 +28,16 @@
   exits:
     "Forest Temple Main": "true"
     "Forest Temple Map Room": "true"
-    "Forest Temple Well": "event(FOREST_WELL)"
+    "Forest Temple Well": "event(FOREST_WELL) || can_dive_big"
+  locations:
+    "Forest Temple GS Garden West": "can_longshot || (event(FOREST_LEDGE_REACHED) && can_collect_distance)"
 "Forest Temple Garden West Ledge":
   dungeon: Forest
   exits:
     "Forest Temple Garden West": "true"
     "Forest Temple Floormaster": "true"
-  locations:
-    "Forest Temple GS Garden West": "can_hookshot"
+  events:
+    FOREST_LEDGE_REACHED: "true"
 "Forest Temple Floormaster":
   dungeon: Forest
   locations:
@@ -59,18 +61,20 @@
     "Forest Temple Garden": "can_hookshot"
     "Forest Temple GS Garden East": "can_hookshot"
   exits:
-    "Forest Temple Well": "event(FOREST_WELL)"
+    "Forest Temple Well": "event(FOREST_WELL) || can_dive_big"
+    "Forest Temple Garden East Ledge": "can_longshot"
 "Forest Temple Well":
   dungeon: Forest
   exits:
     "Forest Temple Garden West": "true"
     "Forest Temple Garden East": "true"
   locations:
-    "Forest Temple Well": "true"
+    "Forest Temple Well": "event(FOREST_WELL)"
 "Forest Temple Maze":
   dungeon: Forest
   exits:
     "Forest Temple Main": "true"
+    "Forest Temple Garden West Ledge": "has_hover_boots"
     "Forest Temple Twisted 1 Normal": "has(SMALL_KEY_FOREST, 2) && has(STRENGTH)"
     "Forest Temple Twisted 1 Alt": "has(SMALL_KEY_FOREST, 2) && has(STRENGTH) && can_hit_triggers_distance"
   locations:
@@ -114,7 +118,7 @@
 "Forest Temple Rotating Room":
   dungeon: Forest
   exits:
-    "Forest Temple Twisted 2 Alt": "can_use_bow"
+    "Forest Temple Twisted 2 Alt": "can_use_bow || can_use_din"
 "Forest Temple Twisted 2 Alt":
   dungeon: Forest
   exits:

--- a/data/oot/world/ganon_castle.yml
+++ b/data/oot/world/ganon_castle.yml
@@ -24,36 +24,36 @@
 "Ganon Castle Forest":
   dungeon: Ganon
   events:
-    GANON_TRIAL_FOREST: "has_fire && can_play(SONG_TIME) && has(BOOTS_HOVER) && has(BOOTS_IRON) && has_light_arrows"
+    GANON_TRIAL_FOREST: "(has_fire_arrows || (can_use_din && has_ranged_weapon_adult)) && has_light_arrows"
   locations:
     "Ganon Castle Forest Chest": "true"
 "Ganon Castle Fire":
   dungeon: Ganon
   events:
-    GANON_TRIAL_FIRE: "has(TUNIC_GORON) && can_longshot && has(STRENGTH, 3) && has_light_arrows"
+    GANON_TRIAL_FIRE: "has_tunic_goron && can_longshot && has(STRENGTH, 3) && has_light_arrows"
 "Ganon Castle Water":
   dungeon: Ganon
   events:
-    "BLUE_FIRE": "has_bottle"
-    GANON_TRIAL_WATER: "event(BLUE_FIRE) && has(HAMMER) && has_light_arrows"
+    BLUE_FIRE: "has_bottle"
+    GANON_TRIAL_WATER: "event(BLUE_FIRE) && can_hammer && has_light_arrows"
   locations:
     "Ganon Castle Water Chest 1": "true"
     "Ganon Castle Water Chest 2": "true"
 "Ganon Castle Spirit":
   dungeon: Ganon
   events:
-    GANON_TRIAL_SPIRIT: "can_hookshot && has_bombchu && has_fire && has_light_arrows"
+    GANON_TRIAL_SPIRIT: "can_hookshot && has_explosives && has_light_arrows"
   locations:
-    "Ganon Castle Spirit Chest 1": "can_hookshot && (has(MAGIC_UPGRADE) || has_bombchu)"
-    "Ganon Castle Spirit Chest 2": "can_hookshot && has_bombchu && has_lens"
+    "Ganon Castle Spirit Chest 1": "can_hookshot"
+    "Ganon Castle Spirit Chest 2": "can_hookshot && has_explosives && has_lens"
 "Ganon Castle Shadow":
   dungeon: Ganon
   events:
-    GANON_TRIAL_SHADOW: "has(BOOTS_HOVER) && has_lens && has_fire_arrows && has(HAMMER) && has_light_arrows"
+    GANON_TRIAL_SHADOW: "can_hammer && has_light_arrows && (can_longshot || has_fire_arrows) && (has_hover_boots || has_fire) && (has_lens || (can_longshot && has_hover_boots))"
   locations:
-    "Ganon Castle Shadow Chest 1": "can_play(SONG_ZELDA) || can_hookshot || has(BOOTS_HOVER) || (has_lens && has_fire_arrows)"
-    "Ganon Castle Shadow Chest 2": "has(BOOTS_HOVER) && has_lens && has_fire_arrows"
+    "Ganon Castle Shadow Chest 1": "can_play(SONG_TIME) || can_hookshot || has_hover_boots || has_fire_arrows"
+    "Ganon Castle Shadow Chest 2": "(can_longshot || has_fire_arrows) && (has_hover_boots || has_fire)"
 "Ganon Castle Tower":
   dungeon: Ganon
   locations:
-    "Ganon Castle Boss Key": "true"
+    "Ganon Castle Boss Key": "has_weapon"

--- a/data/oot/world/shadow_temple.yml
+++ b/data/oot/world/shadow_temple.yml
@@ -2,49 +2,49 @@
   dungeon: Shadow
   exits:
     "Graveyard Upper": "true"
-    "Shadow Temple Pit": "has(BOOTS_HOVER) || can_hookshot"
+    "Shadow Temple Pit": "has_hover_boots || can_hookshot"
 "Shadow Temple Pit":
   dungeon: Shadow
   exits:
-    "Shadow Temple Main": "has(BOOTS_HOVER) && has_lens"
+    "Shadow Temple Main": "has_hover_boots && has_lens"
   locations:
     "Shadow Temple Map": "has_lens"
     "Shadow Temple Hover Boots": "has_lens"
 "Shadow Temple Main":
   dungeon: Shadow
   exits:
-    "Shadow Temple Open": "has(SMALL_KEY_SHADOW, 1) && has_explosives_or_hammer"
+    "Shadow Temple Open": "has(SMALL_KEY_SHADOW, 1) && has_explosives"
   locations:
-    "Shadow Temple Silver Rupees": "can_hookshot"
+    "Shadow Temple Silver Rupees": "can_hookshot || has_hover_boots"
     "Shadow Temple Compass": "true"
 "Shadow Temple Open":
   dungeon: Shadow
   exits:
-    "Shadow Temple Wind": "has(SMALL_KEY_SHADOW, 3) && can_hookshot"
+    "Shadow Temple Wind": "has(SMALL_KEY_SHADOW, 3) && can_hookshot && has_lens"
   locations:
     "Shadow Temple Spinning Blades Visible": "true"
-    "Shadow Temple Spinning Blades Invisible": "true"
-    "Shadow Temple Falling Spikes Lower": "has(STRENGTH)"
-    "Shadow Temple Falling Spikes Upper 1": "has(STRENGTH)"
-    "Shadow Temple Falling Spikes Upper 2": "has(STRENGTH)"
-    "Shadow Temple Invisible Spike Room": "has(SMALL_KEY_SHADOW, 2) && can_hookshot"
-    "Shadow Temple Skull": "has(SMALL_KEY_SHADOW, 2) && can_hookshot && has(BOMB_BAG)"
-    "Shadow Temple GS Skull Pot": "has(SMALL_KEY_SHADOW, 2) && can_hookshot"
-    "Shadow Temple GS Falling Spikes": "has(STRENGTH)"
-    "Shadow Temple GS Invisible Scythe": "can_hookshot"
+    "Shadow Temple Spinning Blades Invisible": "has_lens"
+    "Shadow Temple Falling Spikes Lower": "true"
+    "Shadow Temple Falling Spikes Upper 1": "has(STRENGTH) && has_lens"
+    "Shadow Temple Falling Spikes Upper 2": "has(STRENGTH) && has_lens"
+    "Shadow Temple Invisible Spike Room": "has(SMALL_KEY_SHADOW, 2) && can_hookshot && has_lens"
+    "Shadow Temple Skull": "has(SMALL_KEY_SHADOW, 2) && can_hookshot && has_explosives && has_lens"
+    "Shadow Temple GS Skull Pot": "has(SMALL_KEY_SHADOW, 2) && can_hookshot && has_lens"
+    "Shadow Temple GS Falling Spikes": "can_hookshot"
+    "Shadow Temple GS Invisible Scythe": "true"
 "Shadow Temple Wind":
   dungeon: Shadow
   exits:
     "Shadow Temple Boat": "has(SMALL_KEY_SHADOW, 4) && can_play(SONG_ZELDA)"
   locations:
-    "Shadow Temple Wind Room Hint": "true"
+    "Shadow Temple Wind Room Hint": "has_lens"
     "Shadow Temple After Wind": "true"
-    "Shadow Temple After Wind Invisible": "has_explosives"
-    "Shadow Temple GS Near Boat": "has(SMALL_KEY_SHADOW, 4) && scarecrow_longshot"
+    "Shadow Temple After Wind Invisible": "has_explosives && has_lens"
+    "Shadow Temple GS Near Boat": "has(SMALL_KEY_SHADOW, 4) && can_longshot"
 "Shadow Temple Boat":
   dungeon: Shadow
   exits:
-    "Shadow Temple Boss": "has(SMALL_KEY_SHADOW, 5) && has(BOSS_KEY_SHADOW) && has(BOW)"
+    "Shadow Temple Boss": "has(SMALL_KEY_SHADOW, 5) && has(BOSS_KEY_SHADOW) && (can_use_bow || scarecrow_longshot)"
   locations:
     "Shadow Temple Boss Key Room 1": "can_use_din"
     "Shadow Temple Boss Key Room 2": "can_use_din"

--- a/data/oot/world/water_temple.yml
+++ b/data/oot/world/water_temple.yml
@@ -7,26 +7,29 @@
   dungeon: Water
   exits:
     "Water Temple Ruto Room": "has_iron_boots"
-    "Water Temple Center": "has(SMALL_KEY_WATER, 5) || has_fire"
-    "Water Temple Compass Room": "event(WATER_LEVEL_MIDDLE) && can_hookshot"
-    "Water Temple Dragon Room": "event(WATER_LEVEL_RESET) && has(STRENGTH)"
-    "Water Temple Elevator": "event(WATER_LEVEL_MIDDLE) && can_hookshot"
-    "Water Temple Corridor": "can_longshot && has(BOW) && event(WATER_LEVEL_MIDDLE)"
-    "Water Temple Waterfalls": "has(SMALL_KEY_WATER, 4) && can_longshot"
+    "Water Temple Center": "event(WATER_LEVEL_LOW) && (has(SMALL_KEY_WATER, 5) || can_use_din || can_use_bow)"
+    "Water Temple Compass Room": "(can_play(SONG_ZELDA) || has_iron_boots) && can_hookshot"
+    "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has(STRENGTH)"
+    "Water Temple Elevator": "has(SMALL_KEY_WATER, 5) || can_use_din || can_use_bow"
+    "Water Temple Corridor": "(can_longshot || has_hover_boots) && can_use_bow && event(WATER_LEVEL_LOW)"
+    "Water Temple Waterfalls": "has(SMALL_KEY_WATER, 4) && can_longshot && has_iron_boots"
     "Water Temple Large Pit": "has(SMALL_KEY_WATER, 4) && event(WATER_LEVEL_RESET)"
-    "Water Temple Antichamber": "can_longshot"
-    "Water Temple Cage Room": "true"
+    "Water Temple Antichamber": "can_longshot && event(WATER_LEVEL_RESET)"
+    "Water Temple Cage Room": "event(WATER_LEVEL_LOW) && has_explosives && has_iron_boots"
+    "Water Temple Main Ledge": "has_hover_boots"
 "Water Temple Main Ledge":
   dungeon: Water
   events:
-    WATER_LEVEL_RESET: "can_play(SONG_ZELDA)"
+    WATER_LEVEL_RESET: "true"
   exits:
     "Water Temple Main": "true"
 "Water Temple Ruto Room":
   dungeon: Water
   exits:
     "Water Temple Map Room": "event(WATER_LEVEL_RESET)"
-    "Water Temple Shell Room": "event(WATER_LEVEL_RESET) && (has(BOW) || has_fire)"
+    "Water Temple Shell Room": "event(WATER_LEVEL_LOW) && (can_use_bow || has_fire)"
+  events:
+    WATER_LEVEL_LOW: "can_play(SONG_ZELDA)"
   locations:
     "Water Temple Bombable Chest": "event(WATER_LEVEL_MIDDLE) && has_explosives"
 "Water Temple Map Room":
@@ -40,7 +43,7 @@
 "Water Temple Center":
   dungeon: Water
   exits:
-    "Water Temple Under Center": "event(WATER_LEVEL_MIDDLE)"
+    "Water Temple Under Center": "event(WATER_LEVEL_MIDDLE) && has_iron_boots"
   events:
     WATER_LEVEL_MIDDLE: "can_hookshot && can_play(SONG_ZELDA)"
   locations:
@@ -56,11 +59,11 @@
 "Water Temple Dragon Room":
   dungeon: Water
   locations:
-    "Water Temple Dragon Chest": "can_hookshot"
+    "Water Temple Dragon Chest": "can_hookshot && has_iron_boots"
 "Water Temple Elevator":
   dungeon: Water
   exits:
-    "Water Temple Main Ledge": "can_hookshot"
+    "Water Temple Main Ledge": "has_ranged_weapon || has_explosives"
 "Water Temple Corridor":
   dungeon: Water
   locations:
@@ -69,10 +72,11 @@
   dungeon: Water
   exits:
     "Water Temple Blocks": "true"
+    "Water Temple Waterfalls Ledge": has_hover_boots
 "Water Temple Blocks":
   dungeon: Water
   exits:
-    "Water Temple Waterfalls Ledge": "true"
+    "Water Temple Waterfalls Ledge": "has_explosives && has(STRENGTH)"
 "Water Temple Waterfalls Ledge":
   dungeon: Water
   exits:
@@ -105,13 +109,15 @@
     "Water Temple Longshot": "true"
 "Water Temple River":
   dungeon: Water
+  exits:
+    "Water Temple Dragon Room": "can_use_bow"
   locations:
-    "Water Temple River Chest": "can_longshot"
+    "Water Temple River Chest": "can_use_bow"
     "Water Temple GS River": "can_longshot"
 "Water Temple Cage Room":
   dungeon: Water
   locations:
-    "Water Temple GS Cage": "can_longshot && has(MAGIC_UPGRADE)"
+    "Water Temple GS Cage": "can_hookshot"
 "Water Temple Antichamber":
   dungeon: Water
   exits:


### PR DESCRIPTION
- Accounts for the ability to defeat the Dexihand in the well to obtain hot spring water
- Accounts for either source of beans for forward well
- Accounts for reverse well for Mirror Shield and right path chests
- Split Ikana Castle up into more regions to account for potential ER
- Accounts for having a weapon to activate the entrance crystal
- Accounts for the ability to defeat the Wizzrobe to reach the roof
- Accounts for the ability to defeat Igos and his guards
- Added macro for activating grounded switches