### PR TITLE
OoTR Compliance Update: Forest Temple

### DIFF
--- a/data/oot/world/forest_temple.yml
+++ b/data/oot/world/forest_temple.yml
@@ -4,8 +4,8 @@
     "Sacred Meadow": "true"
     "Forest Temple Main": "true"
   locations:
-    "Forest Temple Tree Small Key": "can_hookshot"
-    "Forest Temple GS Entrance": "can_collect_distance"
+    "Forest Temple Tree Small Key": "true"
+    "Forest Temple GS Entrance": "has_ranged_weapon || has_explosives || can_use_din"
 "Forest Temple Main":
   dungeon: Forest
   exits:
@@ -28,14 +28,16 @@
   exits:
     "Forest Temple Main": "true"
     "Forest Temple Map Room": "true"
-    "Forest Temple Well": "event(FOREST_WELL)"
+    "Forest Temple Well": "event(FOREST_WELL) || can_dive_big"
+  locations:
+    "Forest Temple GS Garden West": "can_longshot || (event(FOREST_LEDGE_REACHED) && can_collect_distance)"
 "Forest Temple Garden West Ledge":
   dungeon: Forest
   exits:
     "Forest Temple Garden West": "true"
     "Forest Temple Floormaster": "true"
-  locations:
-    "Forest Temple GS Garden West": "can_hookshot"
+  events:
+    FOREST_LEDGE_REACHED: "true"
 "Forest Temple Floormaster":
   dungeon: Forest
   locations:
@@ -59,18 +61,20 @@
     "Forest Temple Garden": "can_hookshot"
     "Forest Temple GS Garden East": "can_hookshot"
   exits:
-    "Forest Temple Well": "event(FOREST_WELL)"
+    "Forest Temple Well": "event(FOREST_WELL) || can_dive_big"
+    "Forest Temple Garden East Ledge": "can_longshot"
 "Forest Temple Well":
   dungeon: Forest
   exits:
     "Forest Temple Garden West": "true"
     "Forest Temple Garden East": "true"
   locations:
-    "Forest Temple Well": "true"
+    "Forest Temple Well": "event(FOREST_WELL)"
 "Forest Temple Maze":
   dungeon: Forest
   exits:
     "Forest Temple Main": "true"
+    "Forest Temple Garden West Ledge": "has_hover_boots"
     "Forest Temple Twisted 1 Normal": "has(SMALL_KEY_FOREST, 2) && has(STRENGTH)"
     "Forest Temple Twisted 1 Alt": "has(SMALL_KEY_FOREST, 2) && has(STRENGTH) && can_hit_triggers_distance"
   locations:
@@ -114,7 +118,7 @@
 "Forest Temple Rotating Room":
   dungeon: Forest
   exits:
-    "Forest Temple Twisted 2 Alt": "can_use_bow"
+    "Forest Temple Twisted 2 Alt": "can_use_bow || can_use_din"
 "Forest Temple Twisted 2 Alt":
   dungeon: Forest
   exits:


### PR DESCRIPTION
This sorts out some Forest logic, making it generally more robust. Changes include accounting for using the well as a connector, properly handling shenanigans with the ledges involving Longshot and Hover Boots, and recognizing that Din's Fire can melt the frozen switch late in the dungeon (fun fact: frozen switches only care if they thaw, not if they actually get shot).