### PR TITLE
Improve logic for the Mountains and Milk Road

### DIFF
--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -329,7 +329,6 @@
     "Woodfall Shrine": "has(MASK_DEKU)"
     "Woodfall Near Great Fairy Fountain": "has(HOOKSHOT) && has(MASK_DEKU)"
   locations:
-    "Woodfall Near Owl Chest": "has(MASK_DEKU)"
     "Woodfall Entrance Chest": "has(MASK_DEKU) || has(HOOKSHOT)"
     "Woodfall HP Chest": "has(MASK_DEKU) || has(HOOKSHOT)"
 "Woodfall Shrine":
@@ -348,7 +347,6 @@
     "Woodfall": "has(MASK_DEKU)"
     "Woodfall Shrine": "has(MASK_DEKU)"
     "Woodfall Great Fairy Fountain": "has(MASK_DEKU)"
-    "INITIAL": "can_play(SONG_SOARING)"
 "Woodfall Great Fairy Fountain":
   region: WOODFALL
   exits:
@@ -466,7 +464,6 @@
   exits:
     "Goron Village": "can_use_lens"
     "Lone Peak Shrine": "true"
-    "INITIAL": "can_play(SONG_SOARING)"
 "Lone Peak Shrine":
   region: GORON_VILLAGE
   exits:

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -348,7 +348,7 @@
     "Woodfall": "has(MASK_DEKU)"
     "Woodfall Shrine": "has(MASK_DEKU)"
     "Woodfall Great Fairy Fountain": "has(MASK_DEKU)"
-    "Soaring Map": "can_play(SONG_SOARING)"
+    "INITIAL": "can_play(SONG_SOARING)"
 "Woodfall Great Fairy Fountain":
   region: WOODFALL
   exits:
@@ -466,7 +466,7 @@
   exits:
     "Goron Village": "can_use_lens"
     "Lone Peak Shrine": "true"
-    "Soaring Map": "can_play(SONG_SOARING)"
+    "INITIAL": "can_play(SONG_SOARING)"
 "Lone Peak Shrine":
   region: GORON_VILLAGE
   exits:
@@ -790,16 +790,3 @@
     "Stone Tower Inverted Chest 1": "true"
     "Stone Tower Inverted Chest 2": "true"
     "Stone Tower Inverted Chest 3": "true"
-"Soaring Map":
-  region: NONE
-  exits:
-    "Clock Town South": "event(CLOCK_TOWN_OWL)"
-    "Swamp Front": "event(SWAMP_OWL)"
-    "Woodfall Shrine": "event(WOODFALL_OWL)"
-    "Mountain Village": "event(MOUNTAIN_VILLAGE_OWL)"
-    "Snowhead": "event(SNOWHEAD_OWL)"
-    "Milk Road": "event(MILK_ROAD_OWL)"
-    "Great Bay Coast": "event(GREAT_BAY_OWL)"
-    "Zora Cape Peninsula": "event(ZORA_CAPE_OWL)"
-    "Ikana Canyon": "event(IKANA_CANYON_OWL)"
-    "Stone Tower Top": "event(STONE_TOWER_OWL)"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -263,7 +263,7 @@
   events:
     MAGIC_BEANS_SWAMP: "has(MAGIC_BEAN) && (has(MASK_DEKU) || (has(MOON_TEAR) && has(DEED_LAND)))"
     FROG_3: "has(MASK_DON_GERO)"
-    SWAMP_OWL" "true"
+    SWAMP_OWL: "true"
   locations:
     "Southern Swamp HP": "has(DEED_LAND) && has(MASK_DEKU)"
     "Southern Swamp Scrub Deed": "has(DEED_LAND)"
@@ -408,7 +408,7 @@
 "Mountain Village Path":
   region: PATH_TO_MOUNTAIN_VILLAGE
   exits:
-    "Termina Field": "has(BOW) || event(GORON_GRAVEYARD_HOT_WATER)"
+    "Termina Field": "has(BOW)"
     "Mountain Village": "can_break_boulders || can_use_fire_arrows"
 "Mountain Village":
   region: MOUNTAIN_VILLAGE
@@ -799,6 +799,6 @@
     "Snowhead": "event(SNOWHEAD_OWL)"
     "Milk Road": "event(MILK_ROAD_OWL)"
     "Great Bay Coast": "event(GREAT_BAY_OWL)"
-    "Zora Hall Balcony": "event(ZORA_CAPE_OWL)"
+    "Zora Cape Peninsula": "event(ZORA_CAPE_OWL)"
     "Ikana Canyon": "event(IKANA_CANYON_OWL)"
     "Stone Tower Top": "event(STONE_TOWER_OWL)"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -790,7 +790,6 @@
     "Stone Tower Inverted Chest 2": "true"
     "Stone Tower Inverted Chest 3": "true"
 "Soaring Map":
-  region: SOARING_MAP
   exits:
     "Clock Town South": "event(CLOCK_TOWN_OWL)"
     "Swamp Front": "event(SWAMP_OWL)"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -23,6 +23,7 @@
     "Clock Tower Roof": "true"
   events:
     CLOCK_TOWN_SCRUB: "has(MOON_TEAR)"
+    CLOCK_TOWN_OWL: "true"
   locations:
     "Clock Town South Chest Lower": "has(HOOKSHOT) || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB))"
     "Clock Town South Chest Upper": "has(HOOKSHOT) || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB))"
@@ -233,6 +234,8 @@
     "Termina Field Bio Baba Grotto": "can_break_boulders && has(MASK_ZORA)"
     "Termina Field Scrub": "event(SCRUB_TELESCOPE) && has(WALLET)"
     "Termina Field Gossip Stones HP": "has(OCARINA) && ((has(MASK_GORON) && has(SONG_GORON_HALF, 2)) || (has(MASK_DEKU) && has(SONG_AWAKENING)) || (has(MASK_ZORA) && has(SONG_ZORA))) && can_break_boulders"
+#    "Termina Field Log Grotto Cow 1": "has_explosives && can_play(SONG_EPONA)"
+#    "Termina Field Log Grotto Cow 2": "has_explosives && can_play(SONG_EPONA)"
 "Road to Southern Swamp":
   region: ROAD_TO_SWAMP
   exits:
@@ -260,6 +263,7 @@
   events:
     MAGIC_BEANS_SWAMP: "has(MAGIC_BEAN) && (has(MASK_DEKU) || (has(MOON_TEAR) && has(DEED_LAND)))"
     FROG_3: "has(MASK_DON_GERO)"
+    SWAMP_OWL" "true"
   locations:
     "Southern Swamp HP": "has(DEED_LAND) && has(MASK_DEKU)"
     "Southern Swamp Scrub Deed": "has(DEED_LAND)"
@@ -322,16 +326,33 @@
   region: WOODFALL
   exits:
     "Swamp Canopy": "true"
-    "Woodfall Temple Entrance": "has(MASK_DEKU) && can_play(SONG_AWAKENING) && has_weapon"
-    "Woodfall Great Fairy Fountain": "has(MASK_DEKU)"
+    "Woodfall Shrine": "has(MASK_DEKU)"
+    "Woodfall Near Great Fairy Fountain": "has(HOOKSHOT) && has(MASK_DEKU)"
   locations:
     "Woodfall Near Owl Chest": "has(MASK_DEKU)"
     "Woodfall Entrance Chest": "has(MASK_DEKU) || has(HOOKSHOT)"
     "Woodfall HP Chest": "has(MASK_DEKU) || has(HOOKSHOT)"
+"Woodfall Shrine":
+  region: WOODFALL
+  exits:
+    "Woodfall": "has(MASK_DEKU)"
+    "Woodfall Near Great Fairy Fountain": "has(MASK_DEKU)"
+    "Woodfall Temple Entrance": "has(MASK_DEKU) && can_play(SONG_AWAKENING) && has_weapon"
+  events:
+    WOODFALL_OWL: "true"
+  locations:
+    "Woodfall Near Owl Chest": "has(MASK_DEKU) || (has(HOOKSHOT) && can_play(SONG_SOARING))"
+"Woodfall Near Great Fairy Fountain":
+  region: WOODFALL
+  exits:
+    "Woodfall": "has(MASK_DEKU)"
+    "Woodfall Shrine": "has(MASK_DEKU)"
+    "Woodfall Great Fairy Fountain": "has(MASK_DEKU)"
+    "Soaring Map": "can_play(SONG_SOARING)"
 "Woodfall Great Fairy Fountain":
   region: WOODFALL
   exits:
-    "Woodfall": "true"
+    "Woodfall Near Great Fairy Fountain": "true"
   locations:
     "Woodfall Great Fairy": "has(STRAY_FAIRY_WF, 15)"
 "Deku Shrine":
@@ -387,21 +408,23 @@
 "Mountain Village Path":
   region: PATH_TO_MOUNTAIN_VILLAGE
   exits:
-    "Termina Field": "has(BOW)"
+    "Termina Field": "has(BOW) || event(GORON_GRAVEYARD_HOT_WATER)"
     "Mountain Village": "can_break_boulders || can_use_fire_arrows"
 "Mountain Village":
   region: MOUNTAIN_VILLAGE
   exits:
     "Mountain Village Path": "can_break_boulders || can_use_fire_arrows"
     "Twin Islands": "true"
-    "Goron Graveyard": "can_use_lens"
+    "Goron Graveyard": "can_use_lens || (event(BOSS_SNOWHEAD) && has(MASK_GORON))"
     "Path to Snowhead": "true"
     "Blacksmith": "true"
+  events:
+    MOUNTAIN_VILLAGE_OWL: "true"
   locations:
-    "Mountain Village Waterfall Chest": "event(BOSS_SNOWHEAD)"
+    "Mountain Village Waterfall Chest": "event(BOSS_SNOWHEAD) && can_use_lens"
     "Mountain Village Don Gero Mask": "event(GORON_FOOD)"
     "Mountain Village Frog Choir HP": "event(BOSS_SNOWHEAD) && event(FROG_1) && event(FROG_2) && event(FROG_3) && event(FROG_4)"
-    "Mountain Village Tunnel Grotto": "event(BOSS_SNOWHEAD)"
+    "Mountain Village Tunnel Grotto": "event(BOSS_SNOWHEAD) && (has(MASK_GORON) || (can_use_lens && has(MASK_ZORA)))"
 "Blacksmith":
   region: MOUNTAIN_VILLAGE
   exits:
@@ -418,27 +441,35 @@
     "Mountain Village": "true"
     "Goron Village": "true"
     "Goron Race": "can_use_keg"
+  events:
+    TWIN_ISLANDS_HOT_WATER: "(event(GORON_GRAVEYARD_HOT_WATER) || can_use_fire_arrows || event(BOSS_SNOWHEAD) || (event(WELL_HOT_WATER) && can_play(SONG_SOARING))) && has_bottle"
   locations:
     "Twin Islands Underwater Chest 1": "event(BOSS_SNOWHEAD) && has(MASK_ZORA)"
     "Twin Islands Underwater Chest 2": "event(BOSS_SNOWHEAD) && has(MASK_ZORA)"
-    "Twin Islands Frozen Grotto Chest": "(event(GORON_GRAVEYARD_HOT_WATER) || can_use_fire_arrows || (event(WELL_HOT_WATER) && can_play(SONG_SOARING))) && has_explosives"
+    "Twin Islands Frozen Grotto Chest": "(event(GORON_GRAVEYARD_HOT_WATER) || can_use_fire_arrows || event(BOSS_SNOWHEAD) || (event(WELL_HOT_WATER) && can_play(SONG_SOARING))) && has_explosives"
     "Twin Islands Ramp Grotto Chest": "has_explosives && (has(MASK_GORON) || scarecrow_hookshot)"
 "Goron Village":
   region: GORON_VILLAGE
   exits:
     "Twin Islands": "true"
-    "Lone Peak Shrine": "true"
+    "Front of Lone Peak Shrine": "true"
     "Goron Shrine": "true"
   locations:
     "Goron Village HP": "has(DEED_SWAMP) && has(MASK_DEKU)"
     "Goron Village Scrub Deed": "has(DEED_SWAMP) && has(MASK_DEKU)"
-    "Goron Village Scrub Bomb Bag": "has(MASK_GORON) && has(WALLET)"
+    "Goron Village Scrub Bomb Bag": "(has(MASK_GORON) || (has(MOON_TEAR) && has(DEED_LAND) && has(DEED_SWAMP))) && has(WALLET)"
     "Goron Elder": "has(MASK_GORON) && has(OCARINA) && (event(GORON_GRAVEYARD_HOT_WATER) || can_use_fire_arrows || (event(WELL_HOT_WATER) && can_play(SONG_SOARING)))"
     "Goron Powder Keg": "(event(BOSS_SNOWHEAD) || can_use_fire_arrows) && has(MASK_GORON)"
+"Front of Lone Peak Shrine":
+  region: GORON_VILLAGE
+  exits:
+    "Goron Village": "can_use_lens"
+    "Lone Peak Shrine": "true"
+    "Soaring Map": "can_play(SONG_SOARING)"
 "Lone Peak Shrine":
   region: GORON_VILLAGE
   exits:
-    "Goron Village": "can_use_lens || can_play(SONG_SOARING)"
+    "Front of Lone Peak Shrine": "true"
   locations:
     "Lone Peak Shrine Lens Chest": "true"
     "Lone Peak Shrine Boulder Chest": "has_explosives"
@@ -459,20 +490,33 @@
     GORON_FOOD: "has(MASK_GORON) && has(MAGIC_UPGRADE) && (can_use_fire_arrows || can_play(SONG_GORON_HALF))"
   locations:
     "Goron Baby": "has(MASK_GORON) && can_play(SONG_GORON_HALF)"
-"Path to Snowhead":
+"Path to Snowhead Front":
   region: PATH_TO_SNOWHEAD
   exits:
     "Mountain Village": "true"
-    "Snowhead": "goron_fast_roll"
+    "Path to Snowhead Middle": "goron_fast_roll"
+"Path to Snowhead Middle":
+  region: PATH_TO_SNOWHEAD
+  exits:
+    "Path to Snowhead Front": "true"
+    "Path to Snowhead Back": "true"
   locations:
-    "Path to Snowhead HP": "can_use_lens && goron_fast_roll && scarecrow_hookshot"
-    "Path to Snowhead Grotto": "has_explosives && goron_fast_roll"
+    "Path to Snowhead HP": "can_use_lens && scarecrow_hookshot"
+"Path to Snowhead Back":
+  region: PATH_TO_SNOWHEAD
+  exits:
+    "Path to Snowhead Middle": "goron_fast_roll"
+    "Snowhead": "true"
+  locations:
+    "Path to Snowhead Grotto": "has_explosives"
 "Snowhead":
   region: SNOWHEAD
   exits:
-    "Path to Snowhead": "true"
+    "Path to Snowhead Back": "true"
     "Snowhead Temple Entrance": "can_lullaby"
     "Snowhead Great Fairy Fountain": "can_lullaby"
+  events:
+    SNOWHEAD_OWL: "true"
 "Snowhead Great Fairy Fountain":
   region: SNOWHEAD
   exits:
@@ -491,12 +535,15 @@
     "Romani Ranch": "true"
     "Termina Field": "true"
     "Gorman Track": "true"
+  events:
+    MILK_ROAD_OWL: "true"
 "Romani Ranch":
   region: ROMANI_RANCH
   exits:
     "Milk Road": "true"
     "Cucco Shack": "true"
     "Doggy Racetrack": "true"
+    "Stables": "true"
   locations:
     "Romani Ranch Epona Song": "can_use_keg"
     "Romani Ranch Aliens": "can_use_keg && has(BOW)"
@@ -514,6 +561,14 @@
   locations:
     "Doggy Racetrack Chest": "can_use_beans || has(MASK_ZORA) || has(HOOKSHOT)"
     "Doggy Racetrack HP": "has(MASK_TRUTH)"
+"Stables":
+  region: ROMANI_RANCH
+  exits:
+    "Romani Ranch": "true"
+#  locations":
+#    "Stables Cow 1": "can_use_keg && can_play(SONG_EPONA)"
+#    "Stables Cow 2": "can_use_keg && can_play(SONG_EPONA)"
+#    "Stables Cow 3": "can_use_keg && can_play(SONG_EPONA)"
 "Great Bay Coast":
   region: GREAT_BAY_COAST
   exits:
@@ -524,6 +579,8 @@
     "Laboratory": "true"
     "Zora Cape": "true"
     "Ocean Spider House": "true"
+  events:
+    GREAT_BAY_OWL: "true"
   locations:
     "Great Bay Coast Zora Mask": "can_play(SONG_HEALING)"
     "Great Bay Coast HP": "can_use_beans && scarecrow_hookshot"
@@ -559,6 +616,7 @@
   exits:
     "Great Bay Coast": "true"
     "Zora Hall": "has(MASK_ZORA)"
+    "Zora Cape Peninsula": "has(MASK_ZORA)"
     "Waterfall Rapids": "has(HOOKSHOT)"
     "Great Bay Fairy Fountain": "has(MASK_ZORA) && has(HOOKSHOT) && has_explosives"
   locations:
@@ -583,7 +641,7 @@
 "Zora Hall":
   region: ZORA_HALL
   exits:
-    "Zora Cape": "true"
+    "Zora Cape": "has(MASK_ZORA)"
     "Zora Cape Peninsula": "true"
   locations:
     "Zora Hall Scrub HP": "has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_DEKU)"
@@ -593,8 +651,11 @@
 "Zora Cape Peninsula":
   region: ZORA_CAPE
   exits:
+    "Zora Cape": "has(MASK_ZORA)"
     "Zora Hall": "true"
     "Great Bay Temple Entrance": "has(MASK_ZORA) && has(HOOKSHOT) && can_play(SONG_ZORA)"
+  events:
+    ZORA_CAPE_OWL: "true"
 "Ocean Spider House":
   region: GREAT_BAY_COAST
   exits:
@@ -673,8 +734,10 @@
     "Music Box House": "event(IKANA_CURSE_LIFTED)"
     "Ghost Hut": "true"
     "Beneath the Well Entrance": "true"
-    "Ancient Castle of Ikana Exterior": "has_mirror_shield || can_use_light_arrows"
+    "Ancient Castle of Ikana Entrance": "true"
     "Stone Tower": "true"
+  events:
+    IKANA_CANYON_OWL: "true"
 "Ikana Fairy Fountain":
   region: IKANA_CANYON
   exits:
@@ -708,8 +771,10 @@
   region: STONE_TOWER
   exits:
     "Stone Tower": "true"
-    "Stone Tower Temple Entrance": "can_use_elegy3"
-    "Stone Tower Top Inverted": "can_use_elegy3 && can_use_light_arrows"
+    "Stone Tower Temple Entrance": "can_use_elegy"
+    "Stone Tower Top Inverted": "can_use_elegy && can_use_light_arrows"
+  events:
+    STONE_TOWER_OWL: "true"
 "Stone Tower Top Inverted":
   region: STONE_TOWER
   exits:
@@ -724,3 +789,16 @@
     "Stone Tower Inverted Chest 1": "true"
     "Stone Tower Inverted Chest 2": "true"
     "Stone Tower Inverted Chest 3": "true"
+"Soaring Map":
+  region: SOARING_MAP
+  exits:
+    "Clock Town South": "event(CLOCK_TOWN_OWL)"
+    "Swamp Front": "event(SWAMP_OWL)"
+    "Woodfall Shrine": "event(WOODFALL_OWL)"
+    "Mountain Village": "event(MOUNTAIN_VILLAGE_OWL)"
+    "Snowhead": "event(SNOWHEAD_OWL)"
+    "Milk Road": "event(MILK_ROAD_OWL)"
+    "Great Bay Coast": "event(GREAT_BAY_OWL)"
+    "Zora Hall Balcony": "event(ZORA_CAPE_OWL)"
+    "Ikana Canyon": "event(IKANA_CANYON_OWL)"
+    "Stone Tower Top": "event(STONE_TOWER_OWL)"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -416,7 +416,7 @@
     "Mountain Village Path": "can_break_boulders || can_use_fire_arrows"
     "Twin Islands": "true"
     "Goron Graveyard": "can_use_lens || (event(BOSS_SNOWHEAD) && has(MASK_GORON))"
-    "Path to Snowhead": "true"
+    "Path to Snowhead Front": "true"
     "Blacksmith": "true"
   events:
     MOUNTAIN_VILLAGE_OWL: "true"
@@ -457,7 +457,8 @@
   locations:
     "Goron Village HP": "has(DEED_SWAMP) && has(MASK_DEKU)"
     "Goron Village Scrub Deed": "has(DEED_SWAMP) && has(MASK_DEKU)"
-    "Goron Village Scrub Bomb Bag": "(has(MASK_GORON) || (has(MOON_TEAR) && has(DEED_LAND) && has(DEED_SWAMP))) && has(WALLET)"
+    "Goron Village Scrub Bomb Bag": "has(MASK_GORON) && has(WALLET)"
+#    "Goron Village Scrub Bomb Bag": "(has(MASK_GORON) || (has(MOON_TEAR) && has(DEED_LAND) && has(DEED_SWAMP))) && has(WALLET)"
     "Goron Elder": "has(MASK_GORON) && has(OCARINA) && (event(GORON_GRAVEYARD_HOT_WATER) || can_use_fire_arrows || (event(WELL_HOT_WATER) && can_play(SONG_SOARING)))"
     "Goron Powder Keg": "(event(BOSS_SNOWHEAD) || can_use_fire_arrows) && has(MASK_GORON)"
 "Front of Lone Peak Shrine":

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -790,6 +790,7 @@
     "Stone Tower Inverted Chest 2": "true"
     "Stone Tower Inverted Chest 3": "true"
 "Soaring Map":
+  region: NONE
   exits:
     "Clock Town South": "event(CLOCK_TOWN_OWL)"
     "Swamp Front": "event(SWAMP_OWL)"


### PR DESCRIPTION
- Split Woodfall into more regions to account for ER
- Fix various location logic in the mountain region
- Split Path to Snowhead into different regions to account for ER
- Split Lone Peak Shrine into two different regions to account for ER
- Added base for Termina Field and Romani Ranch cow locations
- Added events for all owl statues to account for possible Soaring uses
- Account for only needing to play Elegy once to reach (I)STT