### PR TITLE
MM: Minor Mountain Village tweaks

### DIFF
--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -219,7 +219,7 @@
     "Clock Town East": "true"
     "Clock Town West": "true"
     "Road to Southern Swamp": "true"
-    "Mountain Village Path": "has(BOW)"
+    "Mountain Village Path Lower": "has(BOW)"
     "Milk Road": "true"
     "Great Bay Coast": "can_play(SONG_EPONA)"
     "Road to Ikana": "true"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -465,7 +465,7 @@
   exits:
     "Mountain Village": "true"
     "Goron Village": "true"
-    "Goron Race": "can_use_keg"
+    "Goron Race": "can_use_keg || event(POWDER_KEG_TRIAL)"
   events:
     TWIN_ISLANDS_HOT_WATER: "(event(GORON_GRAVEYARD_HOT_WATER) || can_use_fire_arrows || event(BOSS_SNOWHEAD) || (event(WELL_HOT_WATER) && can_play(SONG_SOARING))) && has_bottle"
   locations:
@@ -479,13 +479,15 @@
     "Twin Islands": "true"
     "Front of Lone Peak Shrine": "true"
     "Goron Shrine": "true"
+  events:
+    POWDER_KEG_TRIAL: "(event(BOSS_SNOWHEAD) || can_use_fire_arrows) && has(MASK_GORON)"
   locations:
     "Goron Village HP": "has(DEED_SWAMP) && has(MASK_DEKU)"
     "Goron Village Scrub Deed": "has(DEED_SWAMP) && has(MASK_DEKU)"
     "Goron Village Scrub Bomb Bag": "has(MASK_GORON) && has(WALLET)"
 #    "Goron Village Scrub Bomb Bag": "(has(MASK_GORON) || (has(MOON_TEAR) && has(DEED_LAND) && has(DEED_SWAMP))) && has(WALLET)"
     "Goron Elder": "has(MASK_GORON) && has(OCARINA) && (event(GORON_GRAVEYARD_HOT_WATER) || can_use_fire_arrows || (event(WELL_HOT_WATER) && can_play(SONG_SOARING)))"
-    "Goron Powder Keg": "(event(BOSS_SNOWHEAD) || can_use_fire_arrows) && has(MASK_GORON)"
+    "Goron Powder Keg": "event(POWDER_KEG_TRIAL)"
 "Front of Lone Peak Shrine":
   region: GORON_VILLAGE
   exits:

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -420,19 +420,24 @@
 # "Swamp Skulltula Pot Room Jar": "true"
 # "Swamp Skulltula Pot Room Wall": "true"
 
-"Mountain Village Path":
+"Mountain Village Path Lower":
   region: PATH_TO_MOUNTAIN_VILLAGE
   exits:
     "Termina Field": "has(BOW)"
-    "Mountain Village": "can_break_boulders || can_use_fire_arrows"
+    "Mountain Village Path Upper": "can_break_boulders || can_use_fire_arrows"
   gossip:
     "Mountain Village Path Gossip": "true"
+"Mountain Village Path Upper":
+  region: PATH_TO_MOUNTAIN_VILLAGE
+  exits:
+    "Mountain Village Path Lower": "can_break_boulders || can_use_fire_arrows"
+    "Mountain Village": "true"
 "Mountain Village":
   region: MOUNTAIN_VILLAGE
   exits:
-    "Mountain Village Path": "can_break_boulders || can_use_fire_arrows"
+    "Mountain Village Path Upper": "true"
     "Twin Islands": "true"
-    "Goron Graveyard": "can_use_lens || (event(BOSS_SNOWHEAD) && has(MASK_GORON))"
+    "Goron Graveyard": "can_use_lens || (event(BOSS_SNOWHEAD) && (has(MASK_GORON) || has(MASK_ZORA)))"
     "Path to Snowhead Front": "true"
     "Blacksmith": "true"
   gossip:
@@ -444,7 +449,7 @@
     "Mountain Village Waterfall Chest": "event(BOSS_SNOWHEAD) && can_use_lens"
     "Mountain Village Don Gero Mask": "event(GORON_FOOD)"
     "Mountain Village Frog Choir HP": "event(BOSS_SNOWHEAD) && event(FROG_1) && event(FROG_2) && event(FROG_3) && event(FROG_4)"
-    "Mountain Village Tunnel Grotto": "event(BOSS_SNOWHEAD) && (has(MASK_GORON) || (can_use_lens && has(MASK_ZORA)))"
+    "Mountain Village Tunnel Grotto": "event(BOSS_SNOWHEAD) && (has(MASK_GORON) || has(MASK_ZORA))"
 "Blacksmith":
   region: MOUNTAIN_VILLAGE
   exits:


### PR DESCRIPTION
- Splits Mountain Village Path into two
- Removes Lens from Zora requirement for reaching Goron Graveyard and the grotto
- Adds Powder Keg Trial as an alternative to open the goron racetrack