### PR TITLE
MM: Improve logic for Pirate Fortress

### DIFF
--- a/data/mm/macros.yml
+++ b/data/mm/macros.yml
@@ -25,3 +25,4 @@
 "can_lullaby": "has(OCARINA) && has(SONG_GORON_HALF, 2) && has(MASK_GORON)"
 "has_shield": "true"
 "can_activate_crystal": "can_break_boulders || has_weapon || has(BOW) || has(HOOKSHOT) || has(MASK_DEKU) || has(MASK_ZORA)"
+"can_evade_gerudo": "has(BOW) || has(HOOKSHOT) || has(MASK_ZORA) || has(MASK_STONE)"

--- a/data/mm/pool.csv
+++ b/data/mm/pool.csv
@@ -211,8 +211,8 @@ Pirate Fortress Sewers HP,                      collectible,  PIRATE_FORTRESS_IN
 Pirate Fortress Interior Hookshot,                chest,        PIRATE_FORTRESS_INTERIOR, 0x02, HOOKSHOT
 Pirate Fortress Interior Aquarium,                chest,        PIRATE_FORTRESS_INTERIOR, 0x00, RUPEE_RED
 Pirate Fortress Interior Silver Rupee Chest,      chest,        PIRATE_FORTRESS_INTERIOR, 0x03, RUPEE_SILVER
-Pirate Fortress Exterior Lower Chest,             chest,        PIRATE_FORTRESS_EXTERIOR, 0x00, RUPEE_RED
-Pirate Fortress Exterior Upper Chest,             chest,        PIRATE_FORTRESS_EXTERIOR, 0x01, RUPEE_RED
+Pirate Fortress Interior Lower Chest,             chest,        PIRATE_FORTRESS_EXTERIOR, 0x00, RUPEE_RED
+Pirate Fortress Interior Upper Chest,             chest,        PIRATE_FORTRESS_EXTERIOR, 0x01, RUPEE_RED
 Great Bay Temple Map,                             chest,          TEMPLE_GREAT_BAY, 0x1d,           MAP_GB
 Great Bay Temple Baba Chest,                      chest,          TEMPLE_GREAT_BAY, 0x19,           STRAY_FAIRY_GB
 Great Bay Temple Boss Key,                        chest,          TEMPLE_GREAT_BAY, 0x1e,           BOSS_KEY_GB

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -650,6 +650,10 @@
 #    "Great Bay Coard Ledge Cow 2": "has(HOOKSHOT) && can_play(SONG_EPONA)"
   gossip:
     "Great Bay Coast Gossip": "true"
+"Great Bay Coast Captured":
+  region: GREAT_BAY_COAST
+  exits:
+    "Great Bay Coast": "true"
 "Fisher's Hut":
   region: GREAT_BAY_COAST
   exits:
@@ -676,7 +680,7 @@
   exits:
     "Great Bay Coast": "true"
   locations:
-    "Laboratory Zora Song": "event(ZORA_EGGS_PIRATE) && event(ZORA_EGGS_PINNACLE_ROCK) && has(MASK_ZORA) && has(OCARINA)"
+    "Laboratory Zora Song": "event(ZORA_EGGS_HOOKSHOT_ROOM) && event(ZORA_EGGS_BARREL_MAZE) && event(ZORA_EGGS_LONE_GUARD) && event(ZORA_EGGS_TREASURE_ROOM) && event(ZORA_EGGS_PINNACLE_ROCK) && has(MASK_ZORA) && has(OCARINA)"
     "Laboratory Fish HP": "has_bottle"
 "Zora Cape":
   region: ZORA_CAPE

--- a/data/mm/world/pirate_fortress.yml
+++ b/data/mm/world/pirate_fortress.yml
@@ -1,40 +1,147 @@
 "Pirate Fortress Entrance":
   region: PIRATE_FORTRESS_EXTERIOR
   exits:
+    "Great Bay Coast": "has(MASK_ZORA)"
+    "Great Bay Coast Captured": "true"
     "Pirate Fortress Sewers": "has(MASK_ZORA) && has(MASK_GORON)"
-    "Pirate Fortress Exterior": "has(HOOKSHOT)"
+    "Pirate Fortress Entrance Balcony": "has(HOOKSHOT)"
   events:
     PHOTO_GERUDO: "has(PICTOGRAPH_BOX)"
   locations:
     "Pirate Fortress Entrance Chest 1": "has(MASK_ZORA)"
     "Pirate Fortress Entrance Chest 2": "has(MASK_ZORA)"
     "Pirate Fortress Entrance Chest 3": "has(MASK_ZORA)"
+"Pirate Fortress Entrance Balcony":
+  region: PIRATE_FORTRESS_EXTERIOR
+  exits:
+    "Pirate Fortress Entrance": "true"
+    "Pirate Fortress Sewers End": "true"
+    "Pirate Fortress Interior": "true"
 "Pirate Fortress Sewers":
   region: PIRATE_FORTRESS_SEWERS
   exits:
-    "Pirate Fortress Exterior": "true"
+    "Pirate Fortress Entrance": "true"
+    "Pirate Fortress Sewers End": "has(MASK_ZORA)"
   locations:
-    "Pirate Fortress Sewers Chest 1": "true"
-    "Pirate Fortress Sewers Chest 2": "true"
-    "Pirate Fortress Sewers Chest 3": "true"
-    "Pirate Fortress Sewers HP": "true"
-"Pirate Fortress Exterior":
+    "Pirate Fortress Sewers Chest 1": "has(MASK_ZORA)"
+    "Pirate Fortress Sewers Chest 2": "has(MASK_ZORA)"
+    "Pirate Fortress Sewers Chest 3": "has(MASK_ZORA)"
+    "Pirate Fortress Sewers HP": "has(MASK_ZORA)"
+"Pirate Fortress Sewers End":
+  region: PIRATE_FORTRESS_SEWERS
+  exits:
+    "Pirate Fortress Entrance": "has(MASK_ZORA)"
+    "Pirate Fortress Entrance Balcony": "true"
+"Pirate Fortress Interior":
   region: PIRATE_FORTRESS_INTERIOR
   exits:
-    "Pirate Fortress Entrance": "true"
-    "Pirate Fortress Interior Hookshot Room": "has(BOW) || can_use_deku_bubble"
-    "Pirate Fortress Interior Other Rooms": "has(HOOKSHOT)"
+    "Pirate Fortress Entrance Balcony": "true"
+    "Pirate Fortress Hookshot Room Upper": "can_evade_gerudo"
+    "Pirate Fortress Hookshot Room Lower": "true"
+    "Pirate Fortress Lone Guard Entry": "has(HOOKSHOT)"
+    "Pirate Fortress Barrel Maze Entry": "has(HOOKSHOT)"
+    "Pirate Fortress Entrance Captured": "true"
+  locations:
+    "Pirate Fortress Interior Lower Chest": "true"
+    "Pirate Fortress Interior Upper Chest": "has(HOOKSHOT)"
+"Pirate Fortress Hookshot Room Upper":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Interior": "true"
   events:
-    ZORA_EGGS_PIRATE: "has(HOOKSHOT) && has(MASK_ZORA) && has_bottle && has_weapon"
-  locations:
-    "Pirate Fortress Exterior Lower Chest": "true"
-    "Pirate Fortress Exterior Upper Chest": "has(HOOKSHOT)"
-"Pirate Fortress Interior Hookshot Room":
+    FORTRESS_BEEHIVE: "has(BOW) || can_use_deku_bubble"
+"Pirate Fortress Hookshot Room Lower":
   region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Interior": "true"
+    "Pirate Fortress Entrance Captured": "true"
+  events:
+    FORTRESS_BEEHIVE: "has(MASK_STONE) && has(HOOKSHOT) && (has(BOW) || can_use_deku_bubble)"
+    ZORA_EGGS_HOOKSHOT_ROOM: "has(HOOKSHOT) && has(MASK_ZORA) && has_bottle && (has(MASK_STONE) || event(FORTRESS_BEEHIVE))"
   locations:
-    "Pirate Fortress Interior Hookshot": "true"
-"Pirate Fortress Interior Other Rooms":
+    "Pirate Fortress Interior Hookshot": "event(FORTRESS_BEEHIVE)"
+"Pirate Fortress Barrel Maze Entry":
   region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Interior": "true"
+    "Pirate Fortress Entrance Lookout": "true"
+    "Pirate Fortress Barrel Maze": "true"
+"Pirate Fortress Entrance Lookout":
+  region: PIRATE_FORTRESS_EXTERIOR
+  exits:
+    "Pirate Fortress Barrel Maze Entry": "true"
+    "Pirate Fortress Entrance": "true"
+"Pirate Fortress Barrel Maze":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Barrel Maze Entry": "true"
+    "Pirate Fortress Barrel Maze Aquarium": "has_weapon && can_evade_gerudo"
+    "Pirate Fortress Entrance Captured": "true"
+"Pirate Fortress Barrel Maze Aquarium":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Barrel Maze": "has_weapon"
+    "Pirate Fortress Barrel Maze Exit": "true"
+  events:
+    ZORA_EGGS_BARREL_MAZE: "has(HOOKSHOT) && has(MASK_ZORA) && has_bottle"
+"Pirate Fortress Barrel Maze Exit":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Barrel Maze Aquarium": "true"
+    "Pirate Fortress Interior": "true"
+"Pirate Fortress Lone Guard Entry":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Interior": "true"
+    "Pirate Fortress Lone Guard": "true"
+    "Pirate Fortress Treasure Room Entry": "has(HOOKSHOT)"
+"Pirate Fortress Lone Guard":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Lone Guard Aquarium": "has_weapon && can_evade_gerudo"
+    "Pirate Fortress Lone Guard Entry": "true"
+    "Pirate Fortress Entrance Captured": "true"
+"Pirate Fortress Lone Guard Aquarium":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Lone Guard": "has_weapon"
+    "Pirate Fortress Lone Guard Exit": "true"
+  events:
+    ZORA_EGGS_LONE_GUARD: "has(HOOKSHOT) && has(MASK_ZORA) && has_bottle"
   locations:
-    "Pirate Fortress Interior Aquarium": "has(MASK_ZORA)"
-    "Pirate Fortress Interior Silver Rupee Chest": "true"
+    "Pirate Fortress Interior Aquarium": "has(MASK_ZORA) && has(HOOKSHOT)"
+"Pirate Fortress Lone Guard Exit":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Lone Guard Aquarium": "true"
+    "Pirate Fortress Interior": "true"
+"Pirate Fortress Treasure Room Entry":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Interior": "can_evade_gerudo"
+    "Pirate Fortress Treasure Room": "true"
+    "Pirate Fortress Entrance Captured": "true"
+"Pirate Fortress Treasure Room":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Treasure Room Aquarium": "has_weapon && can_evade_gerudo"
+    "Pirate Fortress Treasure Room Entry": "true"
+    "Pirate Fortress Entrance Captured": "true"
+  locations:
+    "Pirate Fortress Interior Silver Rupee Chest": "can_evade_gerudo"
+"Pirate Fortress Treasure Room Aquarium":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Treasure Room": "has_weapon"
+    "Pirate Fortress Treasure Room Exit": "true"
+  events:
+    ZORA_EGGS_TREASURE_ROOM: "has(HOOKSHOT) && has(MASK_ZORA) && has_bottle"
+"Pirate Fortress Treasure Room Exit":
+  region: PIRATE_FORTRESS_INTERIOR
+  exits:
+    "Pirate Fortress Treasure Room Aquarium": "true"
+    "Pirate Fortress Interior": "true"
+"Pirate Fortress Entrance Captured":
+  region: PIRATE_FORTRESS_EXTERIOR
+  exits:
+    "Pirate Fortress Entrance Balcony": "true"


### PR DESCRIPTION
- Splits up Pirate Fortress into many more areas to account for all possibilities of ER
- Adds event for the Hookshot beehive since it can be triggered from either door
- Adds new macro for the ability to evade Gerudo guards