### PR TITLE
Logic Bug Fix

### DIFF
--- a/data/oot/world/dodongo_cavern.yml
+++ b/data/oot/world/dodongo_cavern.yml
@@ -58,7 +58,7 @@
     "Dodongo Cavern Bomb Bag Room 1": "true"
   locations:
     "Dodongo Cavern GS Stairs Vines": "true"
-    "Dodongo Cavern GS Stairs Top": "can_hookshot || can_boomerang"
+    "Dodongo Cavern GS Stairs Top": "(can_hookshot || can_boomerang) && event(DC_SHORTCUT)"
 "Dodongo Cavern Compass Room":
   dungeon: DC
   exits:


### PR DESCRIPTION
My bad! This GS location didn't check for the shortcut being opened, thus allowing for impossible seeds in which Slingshot isn't available but Boomerang is.