### PR TITLE
Feature: Force junk locations

### DIFF
--- a/lib/combo/index.ts
+++ b/lib/combo/index.ts
@@ -5,7 +5,7 @@ import { Generator } from './generator';
 import { MonitorCallbacks } from './monitor';
 import { SETTINGS, DEFAULT_SETTINGS, SETTINGS_CATEGORIES, Settings, TRICKS } from './settings';
 import { createWorld } from './logic/world';
-import { alterWorld, configFromSettings } from './logic/settings';
+import { alterWorld, configFromSettings, isShuffled } from './logic/settings';
 import { itemName } from './names';
 import { Items } from './logic/state';
 import { addItem, isDungeonItem, isDungeonReward, isJunk, isStrayFairy, isToken } from './logic/items';
@@ -17,6 +17,10 @@ type GeneratorParams = {
   opts?: OptionsInput,
   monitor?: MonitorCallbacks
 };
+
+type LocInfo = {
+  [k: string]: string[]
+}
 
 export const generate = (params: GeneratorParams): Generator => {
   const opts = options(params.opts || {});
@@ -49,4 +53,22 @@ export const itemPool = (aSettings: Partial<Settings>) => {
     addItem(items, item);
   }
   return items;
+}
+
+export const locationList = (aSettings: Partial<Settings>) => {
+  const settings: Settings = { ...DEFAULT_SETTINGS, ...aSettings };
+  const world = createWorld(settings);
+  const config = configFromSettings(settings);
+  alterWorld(world, settings, config);
+
+  /* Everywhere below Check.type is a placeholder for Check.flags that I am going to add to the item tables. */
+  const locations: LocInfo = {};
+  for (const loc in world.checks) {
+    if (!isShuffled(settings, loc)) {
+      continue;
+    }
+    locations[loc] = [world.checks[loc].type];
+  }
+
+  return locations;
 }

--- a/lib/combo/logic/hints.ts
+++ b/lib/combo/logic/hints.ts
@@ -596,7 +596,7 @@ class HintsSolver {
     if ((isItemMajor(item) || isDungeonReward(item) || isKey(item) || isStrayFairy(item)) && !this.majorItemFoolish(loc, item, wothItems) && !this.isItemUseless(loc)) {
       return -1;
     }
-    if (this.hintedLocations.has(loc) || this.settings.disabledLocations.includes(loc)) {
+    if (this.hintedLocations.has(loc) || this.settings.junkLocations.includes(loc)) {
       return 0;
     }
     return 1;
@@ -664,7 +664,7 @@ class HintsSolver {
         break;
       }
       const locations = this.world.checkHints[checkHint];
-      if (locations.every(l => this.settings.disabledLocations.includes(l))) {
+      if (locations.every(l => this.settings.junkLocations.includes(l))) {
         continue;
       }
       if (this.placeGossipItemExact(checkHint)) {

--- a/lib/combo/logic/hints.ts
+++ b/lib/combo/logic/hints.ts
@@ -596,7 +596,7 @@ class HintsSolver {
     if ((isItemMajor(item) || isDungeonReward(item) || isKey(item) || isStrayFairy(item)) && !this.majorItemFoolish(loc, item, wothItems) && !this.isItemUseless(loc)) {
       return -1;
     }
-    if (this.hintedLocations.has(loc)) {
+    if (this.hintedLocations.has(loc) || this.settings.disabledLocations.includes(loc)) {
       return 0;
     }
     return 1;
@@ -662,6 +662,10 @@ class HintsSolver {
     for (const checkHint of pool) {
       if (placed >= count) {
         break;
+      }
+      const locations = this.world.checkHints[checkHint];
+      if (locations.every(l => this.settings.disabledLocations.includes(l))) {
+        continue;
       }
       if (this.placeGossipItemExact(checkHint)) {
         placed++;
@@ -802,6 +806,11 @@ class HintsSolver {
     const missingHints = 34 - hints;
     if (missingHints > 0) {
       hints += this.placeGossipItemExactPool(HINTS_ITEMS_SOMETIMES, missingHints);
+    }
+
+    /* Ensure there are enough hints */
+    if (hints < 34) {
+      throw new Error(`Not able to generate enough hints to fill each gossip stone.`);
     }
 
     /* Duplicate every hint */

--- a/lib/combo/logic/hints.ts
+++ b/lib/combo/logic/hints.ts
@@ -808,11 +808,6 @@ class HintsSolver {
       hints += this.placeGossipItemExactPool(HINTS_ITEMS_SOMETIMES, missingHints);
     }
 
-    /* Ensure there are enough hints */
-    if (hints < 34) {
-      throw new Error(`Not able to generate enough hints to fill each gossip stone.`);
-    }
-
     /* Duplicate every hint */
     this.duplicateHints();
   }

--- a/lib/combo/logic/settings.ts
+++ b/lib/combo/logic/settings.ts
@@ -117,3 +117,8 @@ export const alterWorld = (world: World, settings: Settings, config: Set<string>
     check.item = item;
   }
 };
+
+/* Added as a placeholder. Currently is only in function that exposes location list to gui  */
+export const isShuffled = (settings: Settings, location: string) => {
+  return true;
+}

--- a/lib/combo/logic/solve.ts
+++ b/lib/combo/logic/solve.ts
@@ -64,7 +64,7 @@ class Solver {
   private pools: ItemPools;
   private reachedLocations = new Set<string>();
   private fixedLocations = new Set<string>();
-  private disabledLocations: string[];
+  private disabledLocations = new Set<string>();
 
   constructor(
     private opts: Options,
@@ -72,7 +72,7 @@ class Solver {
     private random: Random,
   ) {
     this.items = { ...opts.settings.startingItems };
-    this.disabledLocations = [ ...opts.settings.disabledLocations];
+    this.disabledLocations = new Set<string>(opts.settings.disabledLocations);
     this.fixTokens();
     this.fixFairies();
     this.fixLocations();
@@ -363,18 +363,17 @@ class Solver {
 
   private disableLocations() {
     const junkArray = shuffle(this.random, itemsArray(this.pools.junk));
+    const disabledLocations = [ ...this.disabledLocations ];
 
-    if (this.disabledLocations.length > junkArray.length) {
+    if (disabledLocations.length > junkArray.length) {
       throw new Error(`Too many disabled locations, max=${junkArray.length}`);
     }
 
-    for (let i = 0; i < this.disabledLocations.length; i++) {
+    for (let i = 0; i < disabledLocations.length; i++) {
       const junk = junkArray[i];
-      this.place(this.disabledLocations[i], junk);
+      this.place(disabledLocations[i], junk);
       removeItemPools(this.pools, junk);
     }
-  
-    return;
   }
 
   private propagate() {

--- a/lib/combo/logic/solve.ts
+++ b/lib/combo/logic/solve.ts
@@ -64,7 +64,7 @@ class Solver {
   private pools: ItemPools;
   private reachedLocations = new Set<string>();
   private fixedLocations = new Set<string>();
-  private disabledLocations = new Set<string>();
+  private junkLocations = new Set<string>();
 
   constructor(
     private opts: Options,
@@ -72,7 +72,7 @@ class Solver {
     private random: Random,
   ) {
     this.items = { ...opts.settings.startingItems };
-    this.disabledLocations = new Set<string>(opts.settings.disabledLocations);
+    this.junkLocations = new Set<string>(opts.settings.junkLocations);
     this.pools = this.makeItemPools();
     if (this.opts.settings.noLogic) {
       const allLocations = new Set<string>(Object.keys(this.world.checks));
@@ -86,8 +86,8 @@ class Solver {
   solve() {
     const checksCount = Object.keys(this.world.checks).length;
 
-    /* Place junk into disabled locations */
-    this.disableLocations();
+    /* Place junk into junkLocations */
+    this.placeJunkLocations();
 
     /* Place items fixed to default */
     this.fixTokens();
@@ -379,17 +379,17 @@ class Solver {
     }
   }
 
-  private disableLocations() {
+  private placeJunkLocations() {
     const junkArray = shuffle(this.random, itemsArray(this.pools.junk));
-    const disabledLocations = [ ...this.disabledLocations ];
+    const junkLocations = [ ...this.junkLocations ];
 
-    if (disabledLocations.length > junkArray.length) {
-      throw new Error(`Too many disabled locations, max=${junkArray.length}`);
+    if (junkLocations.length > junkArray.length) {
+      throw new Error(`Too many junk locations, max=${junkArray.length}`);
     }
 
-    for (let i = 0; i < disabledLocations.length; i++) {
+    for (let i = 0; i < junkLocations.length; i++) {
       const junk = junkArray[i];
-      this.place(disabledLocations[i], junk);
+      this.place(junkLocations[i], junk);
       removeItemPools(this.pools, junk);
     }
   }
@@ -502,7 +502,7 @@ class Solver {
     if (this.world.checks[location] === undefined) {
       throw new Error('Invalid Location: ' + location);
     }
-    if (!isJunk(item) && this.opts.settings.disabledLocations.includes(location)) {
+    if (!isJunk(item) && this.opts.settings.junkLocations.includes(location)) {
       throw new Error(`Unable to place ${item} at ${location}.`)
     }
     this.placement[location] = item;

--- a/lib/combo/logic/solve.ts
+++ b/lib/combo/logic/solve.ts
@@ -250,7 +250,9 @@ class Solver {
     const locations = new Set([...gs, ...house]);
     const pool = shuffle(this.random, Array.from(locations).map(loc => this.world.checks[loc].item));
     for (const location of locations) {
-      this.place(location, pool.pop()!);
+      const item = pool.pop();
+      this.place(location, item!);
+      removeItemPools(this.pools, item!);
     }
   }
 

--- a/lib/combo/logic/solve.ts
+++ b/lib/combo/logic/solve.ts
@@ -73,9 +73,6 @@ class Solver {
   ) {
     this.items = { ...opts.settings.startingItems };
     this.disabledLocations = new Set<string>(opts.settings.disabledLocations);
-    this.fixTokens();
-    this.fixFairies();
-    this.fixLocations();
     this.pools = this.makeItemPools();
     if (this.opts.settings.noLogic) {
       const allLocations = new Set<string>(Object.keys(this.world.checks));
@@ -89,6 +86,14 @@ class Solver {
   solve() {
     const checksCount = Object.keys(this.world.checks).length;
 
+    /* Place junk into disabled locations */
+    this.disableLocations();
+
+    /* Place items fixed to default */
+    this.fixTokens();
+    this.fixFairies();
+    this.fixLocations();
+
     /* Place the required reward items */
     if (this.opts.settings.dungeonRewardShuffle === 'dungeonBlueWarps') {
       this.fixRewards();
@@ -101,9 +106,6 @@ class Solver {
     for (const dungeon in this.world.dungeons) {
       this.fixDungeon(dungeon);
     }
-
-    /* Place junk into disabled locations */
-    this.disableLocations();
 
     /* Place required itemss */
     for (;;) {
@@ -123,15 +125,24 @@ class Solver {
 
   private fixLocations() {
     if (!this.opts.settings.shuffleGerudoCard) {
-      this.fixedLocations.add('OOT Gerudo Member Card');
+      const location = 'OOT Gerudo Member Card';
+      const item = this.world.checks[location].item;
+      this.place(location, item);
+      removeItemPools(this.pools, item);
     }
 
     if (!this.opts.settings.shuffleMasterSword) {
-      this.fixedLocations.add('OOT Temple of Time Master Sword');
+      const location = 'OOT Temple of Time Master Sword';
+      const item = this.world.checks[location].item;
+      this.place(location, item);
+      removeItemPools(this.pools, item);
     }
 
     if (this.opts.settings.ganonBossKey === 'vanilla') {
-      this.fixedLocations.add('OOT Ganon Castle Boss Key');
+      const location = 'OOT Ganon Castle Boss Key';
+      const item = this.world.checks[location].item;
+      this.place(location, item);
+      removeItemPools(this.pools, item);
     }
   }
 
@@ -253,7 +264,9 @@ class Solver {
     /* Fix the non-shuffled GS */
     for (const location of gsLocations) {
       if (!this.placement[location]) {
-        this.place(location, this.world.checks[location].item);
+        const item = this.world.checks[location].item;
+        this.place(location, item);
+        removeItemPools(this.pools, item);
       }
     }
 
@@ -261,7 +274,9 @@ class Solver {
     if (this.opts.settings.housesSkulltulaTokens !== 'all') {
       for (const location of houseLocations) {
         if (!this.placement[location]) {
-          this.place(location, this.world.checks[location].item);
+          const item = this.world.checks[location].item;
+          this.place(location, item);
+          removeItemPools(this.pools, item);
         }
       }
     }
@@ -271,15 +286,18 @@ class Solver {
     for (const location in this.world.checks) {
       const check = this.world.checks[location];
       if (isTownStrayFairy(check.item) && this.opts.settings.townFairyShuffle === 'vanilla') {
-        this.fixedLocations.add(location);
+        this.place(location, check.item);
+        removeItemPools(this.pools, check.item);
       } else if (isDungeonStrayFairy(check.item)) {
         if (check.type === 'sf') {
           if (this.opts.settings.strayFairyShuffle !== 'anywhere' && this.opts.settings.strayFairyShuffle !== 'ownDungeon') {
-            this.fixedLocations.add(location);
+            this.place(location, check.item);
+            removeItemPools(this.pools, check.item);
           }
         } else {
           if (this.opts.settings.strayFairyShuffle === 'vanilla') {
-            this.fixedLocations.add(location);
+            this.place(location, check.item);
+            removeItemPools(this.pools, check.item);
           }
         }
       }

--- a/lib/combo/logic/spoiler.ts
+++ b/lib/combo/logic/spoiler.ts
@@ -17,7 +17,7 @@ const spoilerHeader = (buffer: string[], seed: string) => {
 const spoilerSettings = (buffer: string[], settings: Settings) => {
   buffer.push('Settings');
   for (const s in settings) {
-    if (s === 'startingItems' || s === 'tricks' || s === 'disabledLocations') {
+    if (s === 'startingItems' || s === 'tricks' || s === 'junkLocations') {
       continue;
     }
     const v = (settings as any)[s];
@@ -51,13 +51,13 @@ const spoilerStartingItems = (buffer: string[], startingItems: {[k: string]: num
   buffer.push('');
 };
 
-const spoilerDisableLocations = (buffer: string[], disabledLocations: string[]) => {
-  if (disabledLocations.length === 0) {
+const spoilerJunkLocations = (buffer: string[], junkLocations: string[]) => {
+  if (junkLocations.length === 0) {
     return;
   }
 
-  buffer.push('Disabled Locations');
-  for (const location of disabledLocations) {
+  buffer.push('Junk Locations');
+  for (const location of junkLocations) {
     buffer.push(`  ${location}`);
   }
   buffer.push('');
@@ -133,7 +133,7 @@ export const spoiler = (world: World, placement: ItemPlacement, spheres: string[
   spoilerSettings(buffer, opts.settings);
   spoilerTricks(buffer, opts.settings.tricks);
   spoilerStartingItems(buffer, opts.settings.startingItems);
-  spoilerDisableLocations(buffer, opts.settings.disabledLocations);
+  spoilerJunkLocations(buffer, opts.settings.junkLocations);
   spoilerEntrances(buffer, entrances);
   spoilerFoolish(buffer, hints.foolish);
   spoilerHints(buffer, hints, placement);

--- a/lib/combo/logic/spoiler.ts
+++ b/lib/combo/logic/spoiler.ts
@@ -17,7 +17,7 @@ const spoilerHeader = (buffer: string[], seed: string) => {
 const spoilerSettings = (buffer: string[], settings: Settings) => {
   buffer.push('Settings');
   for (const s in settings) {
-    if (s === 'startingItems' || s === 'tricks') {
+    if (s === 'startingItems' || s === 'tricks' || s === 'disabledLocations') {
       continue;
     }
     const v = (settings as any)[s];
@@ -47,6 +47,18 @@ const spoilerStartingItems = (buffer: string[], startingItems: {[k: string]: num
   for (const item in startingItems) {
     const count = startingItems[item];
     buffer.push(`  ${item}: ${count}`);
+  }
+  buffer.push('');
+};
+
+const spoilerDisableLocations = (buffer: string[], disabledLocations: string[]) => {
+  if (disabledLocations.length === 0) {
+    return;
+  }
+
+  buffer.push('Disabled Locations');
+  for (const location of disabledLocations) {
+    buffer.push(`  ${location}`);
   }
   buffer.push('');
 };
@@ -121,6 +133,7 @@ export const spoiler = (world: World, placement: ItemPlacement, spheres: string[
   spoilerSettings(buffer, opts.settings);
   spoilerTricks(buffer, opts.settings.tricks);
   spoilerStartingItems(buffer, opts.settings.startingItems);
+  spoilerDisableLocations(buffer, opts.settings.disabledLocations);
   spoilerEntrances(buffer, entrances);
   spoilerFoolish(buffer, hints.foolish);
   spoilerHints(buffer, hints, placement);

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -273,6 +273,7 @@ type SettingsBase = UnionToIntersection<SettingShapes>;
 
 export type Settings = SettingsBase & {
   startingItems: {[k: string]: number},
+  disabledLocations: string[],
   tricks: Tricks,
 };
 

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -236,6 +236,8 @@ const DEFAULT_TRICKS = Object.keys(TRICKS).reduce((tricks, trick) => {
   return tricks;
 }, {} as Tricks);
 
+const DEFAULT_DISABLED_LOCATIONS: string[] = [];
+
 type SettingDataEnumValue = {
   readonly value: string;
   readonly name: string;
@@ -279,6 +281,6 @@ export type Settings = SettingsBase & {
 
 export const DEFAULT_SETTINGS: Settings = { ...SETTINGS.map(s => {
   return {[s.key]: s.default};
-}).reduce((a, b) => ({...a, ...b}), {}), startingItems: {}, tricks: { ...DEFAULT_TRICKS } } as Settings;
+}).reduce((a, b) => ({...a, ...b}), {}), startingItems: {}, disabledLocations: DEFAULT_DISABLED_LOCATIONS, tricks: { ...DEFAULT_TRICKS } } as Settings;
 
 export const settings = (s: Partial<Settings>): Settings => ({...DEFAULT_SETTINGS, ...s});

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -236,7 +236,7 @@ const DEFAULT_TRICKS = Object.keys(TRICKS).reduce((tricks, trick) => {
   return tricks;
 }, {} as Tricks);
 
-const DEFAULT_DISABLED_LOCATIONS: string[] = [];
+const DEFAULT_JUNK_LOCATIONS: string[] = [];
 
 type SettingDataEnumValue = {
   readonly value: string;
@@ -275,12 +275,12 @@ type SettingsBase = UnionToIntersection<SettingShapes>;
 
 export type Settings = SettingsBase & {
   startingItems: {[k: string]: number},
-  disabledLocations: string[],
+  junkLocations: string[],
   tricks: Tricks,
 };
 
 export const DEFAULT_SETTINGS: Settings = { ...SETTINGS.map(s => {
   return {[s.key]: s.default};
-}).reduce((a, b) => ({...a, ...b}), {}), startingItems: {}, disabledLocations: DEFAULT_DISABLED_LOCATIONS, tricks: { ...DEFAULT_TRICKS } } as Settings;
+}).reduce((a, b) => ({...a, ...b}), {}), startingItems: {}, junkLocations: DEFAULT_JUNK_LOCATIONS, tricks: { ...DEFAULT_TRICKS } } as Settings;
 
 export const settings = (s: Partial<Settings>): Settings => ({...DEFAULT_SETTINGS, ...s});


### PR DESCRIPTION
Locations can be added to `disabledLocations = []` in a config file to be disabled. A disabled check has its vanilla item added to the item pool but guarantees that it is randomized to an item from the junk pool. There is also a new section in the spoiler logs to list the disabled locations.

I had to change some existing, unrelated things in the solver to make this work. 
- I moved fixFairies, fixTokens, and fixLocations from the constructor of Solver to Solver.solve(). This means that every function that places a final item on a check is located in Solver.solve(). I had to do this because the function to disable locations needs to be after the itempool is made but before any items are placed. This way, if a location is disabled that should not be (because it is intended to be vanilla or results in impossible logic), it is caught and the randomizer will exit with an error message saying what item could not be placed.
- I changed the aforementioned functions from adding their vanilla checks to Solver.fixedLocations to simply calling Solver.place() and placing the vanilla item there. I left Solver.fixedLocations as is since I wasn't sure if it had other planned uses. I believe with this change it is now unused.

Regarding hints of disabled locations 
- Fixed Hints (e.g. MM Great Fairies): Still hinted if their checks are disabled.
- Foolish Hints: disabled locations do not contribute any weight to the foolish calculation. This means a region with every location disabled will not be hinted foolish.
- Always Hints: If the check is disabled, the always hint is not placed
- Dual Always Hints: If **both** checks are disabled, the always hint is not placed. If only one of the two checks is disabled, the dual always hint will still generate.
- Sometimes Hints: Behavior is identical to both always hints and dual always hints.
If too many hints are omitted this way, the seed will generate but crash on load. I put a super simple check in to fail to generate when this happens. Probably want to make junk hints (or something equivalent) to fill in missing spaces but that is probably beyond the scope of this PR. 

Everything I have listed up above I have extensively tested. If there is any other potential failure mode you see, please let me know and I can look into testing and fixing if need be.

Note: I have not tested this yet with the gui. My expectation (looking at the code) is that it will not impact the gui at all since it is all internal to the core repository at the moment. I wanted to first submit this PR as a yml only feature for the moment just to get review. Currently, there is no way for this to be loaded by the gui but I am going to look into making a new gui element with a simple searchbox to allow all the checks to be shown without having hundreds of lines of checkboxes.