### PR TITLE
MM: Add Zora to poison swamp logic and minor ISTT fix

### DIFF
--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -276,7 +276,7 @@
   exits:
     "Road to Southern Swamp": "true"
     "Tourist Information": "true"
-    "Swamp Back": "event(BOAT_RIDE) || (has(MASK_DEKU) && (has(BOW) || has(HOOKSHOT) || has(MASK_ZORA)))"
+    "Swamp Back": "event(BOAT_RIDE) || (has(MASK_DEKU) && (has(BOW) || has(HOOKSHOT))) || has(MASK_ZORA)"
     "Swamp Potion Shop": "true"
     "Woods of Mystery": "true"
   events:
@@ -291,11 +291,11 @@
 "Swamp Back":
   region: SOUTHERN_SWAMP
   exits:
-    "Swamp Front": "event(BOAT_RIDE) || (has(MASK_DEKU) && has(BOW))"
+    "Swamp Front": "event(BOAT_RIDE) || (has(BOW) && (has(MASK_DEKU) || has(MASK_ZORA)))"
     "Deku Palace": "true"
-    "Swamp Spider House": "has(MASK_DEKU)"
+    "Swamp Spider House": "has(MASK_DEKU) || has(MASK_ZORA)"
   locations:
-    "Southern Swamp Grotto": "has(MASK_DEKU)"
+    "Southern Swamp Grotto": "has(MASK_DEKU) || has(MASK_ZORA)"
 "Tourist Information":
   region: SOUTHERN_SWAMP
   exit:

--- a/data/mm/world/stone_tower_temple.yml
+++ b/data/mm/world/stone_tower_temple.yml
@@ -91,8 +91,8 @@
 "Stone Tower Temple Inverted East":
   dungeon: ST
   exits:
-    "Stone Tower Temple Inverted Entrance": "true"
-    "Stone Tower Temple Inverted Wizzrobe": "has(MASK_DEKU) && can_use_light_arrows  && has(SMALL_KEY_ST, 3)"
+    "Stone Tower Temple Inverted Entrance": "can_use_light_arrows"
+    "Stone Tower Temple Inverted Wizzrobe": "has(MASK_DEKU) && can_use_light_arrows && has(SMALL_KEY_ST, 3)"
     "Stone Tower Temple Inverted Bridge": "trick(MM_ISTT_EYEGORE) && has_shield && has(BOMB_BAG)"
     "Stone Tower Temple Inverted Boss Key Room": trick(MM_ISTT_EYEGORE) && (has(MASK_DEKU) || has(MASK_ZORA))
   events:


### PR DESCRIPTION
This adds Zora as a viable option for getting into Swamp Spider House and the poison swamp grotto. Also accounts for Light Arrows for getting to the ISTT entrance from the east room.