### PR TITLE
MM: Adjust Deku Palace and Woodfall Temple logic

### DIFF
--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -329,13 +329,13 @@
   exits:
     "Swamp Back": "true"
     "Swamp Canopy Front": "has(MASK_DEKU)"
-    "Deku Shrine": "has(MASK_DEKU) && event(DEKU_PRINCESS)"
+    "Deku Shrine": "event(CLEAN_SWAMP)"
   events:
     MAGIC_BEANS_PALACE: "has(MASK_DEKU)"
   locations:
-    "Deku Palace HP": "has(MASK_DEKU)"
-    "Deku Palace Grotto Chest": "has(MASK_DEKU) && (can_use_beans || has(HOOKSHOT))"
-    "Deku Palace Sonata of Awakening": "has(MASK_DEKU) && has(OCARINA) && can_use_beans"
+    "Deku Palace HP": "has(MASK_DEKU) || (event(CLEAN_SWAMP) && can_use_beans)"
+    "Deku Palace Grotto Chest": "(has(MASK_DEKU) && (can_use_beans || has(HOOKSHOT))) || (event(CLEAN_SWAMP) && can_use_beans)"
+    "Deku Palace Sonata of Awakening": "has(MASK_DEKU) && has(OCARINA) && (can_use_beans || trick(MM_PALACE_BEAN_SKIP))"
 "Swamp Canopy Front":
   region: SOUTHERN_SWAMP
   exits:
@@ -395,7 +395,7 @@
   exits:
     "Deku Palace": "true"
   locations:
-    "Deku Shrine Mask of Scents": "true"
+    "Deku Shrine Mask of Scents": "event(DEKU_PRINCESS) && has_weapon_range"
 "Mountain Village Path Lower":
   region: PATH_TO_MOUNTAIN_VILLAGE
   exits:

--- a/data/mm/world/woodfall_temple.yml
+++ b/data/mm/world/woodfall_temple.yml
@@ -17,7 +17,7 @@
     "Woodfall Temple": "true"
     "Woodfall Temple Water Room": "true"
     "Woodfall Temple Maze": "has(SMALL_KEY_WF, 1)"
-    "Woodfall Temple Main Ledge": "event(WOODFALL_TEMPLE_MAIN_FLOWER) || event(WOODFALL_TEMPLE_MAIN_LADDER) || (trick(MM_WFT_HOOKSHOT) && has(HOOKSHOT))"
+    "Woodfall Temple Main Ledge": "event(WOODFALL_TEMPLE_MAIN_FLOWER) || event(WOODFALL_TEMPLE_MAIN_LADDER) || has(HOOKSHOT)"
   events:
     WOODFALL_TEMPLE_MAIN_FLOWER: "can_use_fire_arrows"
   locations:

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -260,7 +260,7 @@ export const TRICKS = {
   OOT_VOLCANO_HOVERS: "Volcano Item with Hover Boots",
   OOT_NIGHT_GS: "Nighttime Gold Skulltulas without Sun's Song",
   MM_LENS: "Fewer Lens Requirements (MM)",
-  MM_WFT_HOOKSHOT: "Woodfall Temple 2F with Hookshot",
+  MM_PALACE_BEAN_SKIP: "Skip Planting Beans in Deku Palace",
   MM_DARMANI_WALL: "Climb Mountain Village Wall Blind",
   MM_NO_SEAHORSE: "Pinnacle Rock without Seahorse",
   MM_ZORA_HALL_HUMAN: "Swim to Zora Hall as Human",


### PR DESCRIPTION
- Accounts for Clean Swamp in Deku Palace to get the two checks without Deku
- Adds the Hookshot to WFT 2F into base logic
- Replaces the above trick with Deku Palace Bean Skip