### PR TITLE
OOT: Fix Forest Temple logic for ER

### DIFF
--- a/data/oot/world/forest_temple.yml
+++ b/data/oot/world/forest_temple.yml
@@ -36,6 +36,7 @@
   exits:
     "Forest Temple Garden West": "true"
     "Forest Temple Floormaster": "true"
+    "Forest Temple Maze": "true"
   events:
     FOREST_LEDGE_REACHED: "true"
 "Forest Temple Floormaster":
@@ -54,15 +55,15 @@
   exits:
     "Forest Temple Garden East": "true"
   events:
-    FOREST_WELL: "can_hookshot"
+    FOREST_WELL: "true"
 "Forest Temple Garden East":
   dungeon: Forest
-  locations:
-    "Forest Temple Garden": "can_hookshot"
-    "Forest Temple GS Garden East": "can_hookshot"
   exits:
     "Forest Temple Well": "event(FOREST_WELL) || can_dive_big"
     "Forest Temple Garden East Ledge": "can_longshot || (can_hookshot && trick(OOT_FOREST_HOOK))"
+  locations:
+    "Forest Temple Garden": "can_hookshot"
+    "Forest Temple GS Garden East": "can_hookshot"
 "Forest Temple Well":
   dungeon: Forest
   exits:
@@ -75,8 +76,8 @@
   exits:
     "Forest Temple Main": "true"
     "Forest Temple Garden West Ledge": "has_hover_boots"
-    "Forest Temple Twisted 1 Normal": "has(SMALL_KEY_FOREST, 2) && has(STRENGTH)"
-    "Forest Temple Twisted 1 Alt": "has(SMALL_KEY_FOREST, 2) && has(STRENGTH) && can_hit_triggers_distance"
+    "Forest Temple Twisted 1 Normal": "is_adult && has(SMALL_KEY_FOREST, 2) && has(STRENGTH)"
+    "Forest Temple Twisted 1 Alt": "is_adult && has(SMALL_KEY_FOREST, 2) && has(STRENGTH) && can_hit_triggers_distance"
   locations:
     "Forest Temple Maze": "has(STRENGTH) && can_hit_triggers_distance"
 "Forest Temple Twisted 1 Normal":
@@ -132,7 +133,7 @@
 "Forest Temple Poe 3":
   dungeon: Forest
   events:
-    FOREST_POE_3: "true"
+    FOREST_POE_3: "can_use_bow"
 "Forest Temple Antichamber":
   dungeon: Forest
   exits:
@@ -144,7 +145,7 @@
   boss: true
   dungeon: Forest
   exits:
-    "Forest Temple After Boss": "(can_use_bow || can_use_slingshot) && has_weapon"
+    "Forest Temple After Boss": "(has_ranged_weapon_adult || can_use_slingshot) && has_weapon"
 "Forest Temple After Boss":
   boss: true
   dungeon: Forest


### PR DESCRIPTION
Removes some item checks that aren't needed and accounts for child not being able to climb the maze room entirely.