### PR TITLE
OOT: Logic overhaul for Dungeon ER

### DIFF
--- a/data/oot/macros.yml
+++ b/data/oot/macros.yml
@@ -40,7 +40,7 @@
 "has_sword_kokiri": "cond(setting(progressiveSwordsOot, progressive), has(SWORD), has(SWORD_KOKIRI))"
 "has_sword_master": "cond(setting(progressiveSwordsOot, progressive), has(SWORD, 2), has(SWORD_MASTER))"
 "has_weapon": "(is_child && has_sword_kokiri) || is_adult"
-"has_tunic_goron": "is_adult && (has(TUNIC_GORON) || trick(OOT_TUNICS))"
+"has_tunic_goron": "(is_adult && has(TUNIC_GORON)) || trick(OOT_TUNICS)"
 "has_tunic_goron_strict": "is_adult && has(TUNIC_GORON)"
 "has_tunic_zora": "is_adult && (has(TUNIC_ZORA) || trick(OOT_TUNICS))"
 "has_tunic_zora_strict": "is_adult && has(TUNIC_ZORA)"

--- a/data/oot/world/deku_tree.yml
+++ b/data/oot/world/deku_tree.yml
@@ -29,7 +29,7 @@
   locations:
     "Deku Tree Basement Chest": "true"
     "Deku Tree GS Basement Gate": "true"
-    "Deku Tree GS Basement Vines": "has_ranged_weapon || can_use_din"
+    "Deku Tree GS Basement Vines": "has_ranged_weapon || can_use_din || has(BOMB_BAG)"
 "Deku Tree Basement Back Room":
   dungeon: DT
   exits:

--- a/data/oot/world/dodongo_cavern.yml
+++ b/data/oot/world/dodongo_cavern.yml
@@ -38,11 +38,17 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Miniboss 1": "true"
+    "Dodongo Cavern Green Side Room": "true"
     "Dodongo Cavern Main Ledge": "is_child || has_fire"
+"Dodongo Cavern Green Side Room":
+  dungeon: DC
+  exits:
+    "Dodongo Cavern Green Room": "true"
 "Dodongo Cavern Main Ledge":
   dungeon: DC
   exits:
     "Dodongo Cavern Main": "true"
+    "Dodongo Cavern Green Room": "true"
   events:
     DC_MAIN_SWITCH: "true"
 "Dodongo Cavern Stairs":
@@ -58,7 +64,7 @@
     "Dodongo Cavern Bomb Bag Room 1": "true"
   locations:
     "Dodongo Cavern GS Stairs Vines": "true"
-    "Dodongo Cavern GS Stairs Top": "(can_hookshot || can_boomerang) && event(DC_SHORTCUT)"
+    "Dodongo Cavern GS Stairs Top": "((can_hookshot || can_boomerang) && event(DC_SHORTCUT)) || can_longshot"
 "Dodongo Cavern Compass Room":
   dungeon: DC
   exits:
@@ -71,6 +77,7 @@
     "Dodongo Cavern Stairs Top": "true"
     "Dodongo Cavern Bomb Bag Room 2": "can_longshot || has_hover_boots || (is_adult && trick(OOT_DC_JUMP))"
     "Dodongo Cavern Miniboss 2": "can_hit_triggers_distance"
+    "Dodongo Cavern Bomb Bag Side Room": "has_explosives_or_hammer"
   locations:
     "Dodongo Cavern Bomb Bag Side Chest": "true"
 "Dodongo Cavern Miniboss 2":

--- a/data/oot/world/dodongo_cavern.yml
+++ b/data/oot/world/dodongo_cavern.yml
@@ -64,7 +64,7 @@
     "Dodongo Cavern Bomb Bag Room 1": "true"
   locations:
     "Dodongo Cavern GS Stairs Vines": "true"
-    "Dodongo Cavern GS Stairs Top": "((can_hookshot || can_boomerang) && event(DC_SHORTCUT)) || can_longshot"
+    "Dodongo Cavern GS Stairs Top": "(can_hookshot || can_boomerang) && event(DC_SHORTCUT)"
 "Dodongo Cavern Compass Room":
   dungeon: DC
   exits:

--- a/data/oot/world/dodongo_cavern.yml
+++ b/data/oot/world/dodongo_cavern.yml
@@ -80,11 +80,15 @@
     "Dodongo Cavern Bomb Bag Side Room": "has_explosives_or_hammer"
   locations:
     "Dodongo Cavern Bomb Bag Side Chest": "true"
+"Dodongo Cavern Bomb Bag Side Room":
+  dungeon: DC
+  exits:
+    "Dodongo Cavern Bomb Bag Room 1": "true"
 "Dodongo Cavern Miniboss 2":
   dungeon: DC
   exits:
     "Dodongo Cavern Bomb Bag Room 1": "true"
-    "Dodongo Cavern Bomb Bag Room 2": "can_hit_triggers_distance"
+    "Dodongo Cavern Bomb Bag Room 2": "true"
 "Dodongo Cavern Bomb Bag Room 2":
   dungeon: DC
   exits:

--- a/data/oot/world/fire_temple.yml
+++ b/data/oot/world/fire_temple.yml
@@ -3,28 +3,28 @@
   exits:
     "Death Mountain Crater Warp": "true"
     "Fire Temple Lava Room": "has_small_keys_fire(1)"
-    "Fire Temple Boss": "has(BOSS_KEY_FIRE) && (event(FIRE_TEMPLE_PILLAR_HAMMER) || has_hover_boots) && has_tunic_goron_strict"
+    "Fire Temple Boss": "has(BOSS_KEY_FIRE) && (event(FIRE_TEMPLE_PILLAR_HAMMER) || has_hover_boots) && has_tunic_goron"
     "Fire Temple Boss Key Loop": "cond(setting(smallKeyShuffle, anywhere), has(SMALL_KEY_FIRE, 8), true) && can_hammer"
   locations:
-    "Fire Temple Jail 1 Chest": "true"
+    "Fire Temple Jail 1 Chest": "has_tunic_goron"
 "Fire Temple Boss Key Loop":
   dungeon: Fire
   locations:
-    "Fire Temple Boss Key Side Chest": "can_hammer"
-    "Fire Temple Boss Key Chest": "can_hammer"
-    "Fire Temple GS Hammer Statues": "can_hammer"
+    "Fire Temple Boss Key Side Chest": "true"
+    "Fire Temple Boss Key Chest": "true"
+    "Fire Temple GS Hammer Statues": "true"
 "Fire Temple Lava Room":
   dungeon: Fire
   exits:
-    "Fire Temple After Elevator": "has_small_keys_fire(3) && has(STRENGTH) && (has_ranged_weapon_adult || has_explosives) && has_tunic_goron_strict"
+    "Fire Temple After Elevator": "has_small_keys_fire(3) && has_tunic_goron_strict"
   locations:
-    "Fire Temple Jail 2 Chest": "true"
-    "Fire Temple Jail 3 Chest": "has_explosives"
-    "Fire Temple GS Lava Side Room": "can_play(SONG_TIME)"
+    "Fire Temple Jail 2 Chest": "has_tunic_goron"
+    "Fire Temple Jail 3 Chest": "has_tunic_goron && has_explosives"
+    "Fire Temple GS Lava Side Room": "has_tunic_goron && can_play(SONG_TIME)"
 "Fire Temple After Elevator":
   dungeon: Fire
   exits:
-    "Fire Temple": "true"
+    "Fire Temple Maze": "has(STRENGTH) && (has_ranged_weapon_adult || has_explosives)"
     "Fire Temple Ring": "has_small_keys_fire(6)"
     "Fire Temple Scarecrow": "has_small_keys_fire(5) && scarecrow_hookshot"
   locations:
@@ -34,10 +34,43 @@
     "Fire Temple Above Maze Chest": "has_small_keys_fire(5)"
     "Fire Temple Below Maze Chest": "has_small_keys_fire(5) && has_explosives"
     "Fire Temple GS Maze": "has_explosives"
+"Fire Temple Maze":
+  dungeon: Fire
+  exits:
+    "Fire Temple Before Map": "has_small_keys_fire(4)"
+  locations:
+    "Fire Temple Maze Chest": "true"
+    "Fire Temple Jail 4 Chest": "true"
+    "Fire Temple GS Maze": "has_explosives"
+"Fire Temple Before Map":
+  dungeon: Fire
+  exits:
+    "Fire Temple Flame Wall": "has_small_keys_fire(5)"
+  locations:
+    "Fire Temple Map": "can_use_bow"
+"Fire Temple Flame Wall":
+  dungeon: Fire
+  exits:
+    "Fire Temple Ring": "has_small_keys_fire(6)"
+    "Fire Temple Maze Upper": "scarecrow_hookshot"
+  locations:
+    "Fire Temple Map": "true"
+"Fire Temple Maze Upper":
+  dungeon: Fire
+  exits:
+    "Fire Temple Scarecrow": "scarecrow_hookshot"
+  locations:
+    "Fire Temple Above Maze Chest": "true"
+    "Fire Temple Below Maze Chest": "has_explosives"
+"Fire Temple Scarecrow":
+  dungeon: Fire
+  locations:
+    "Fire Temple Scarecrow Chest": "true"
+    "Fire Temple GS Scarecrow Wall": "true"
+    "Fire Temple GS Scarecrow Top": "true"
 "Fire Temple Ring":
   dungeon: Fire
   exits:
-    "Fire Temple After Elevator": "true"
     "Fire Temple Before Miniboss": "has_small_keys_fire(7)"
     "Fire Temple Pillar Ledge": "has_hover_boots"
   locations:
@@ -48,7 +81,7 @@
     "Fire Temple After Miniboss": "has_explosives"
     "Fire Temple Pillar Ledge": "can_play(SONG_TIME)"
   locations:
-    "Fire Temple Ring Jail": "can_hammer && (can_play(SONG_TIME) || (trick(OOT_HAMMER_WALLS) && has_hover_boots))"
+    "Fire Temple Ring Jail": "can_hammer && can_play(SONG_TIME)"
 "Fire Temple Pillar Ledge":
   dungeon: Fire
   exits:
@@ -56,23 +89,19 @@
     "Fire Temple Ring": "true"
   events:
     FIRE_TEMPLE_PILLAR_HAMMER: "can_hammer"
+  locations:
+    "Fire Temple Ring Jail": "can_hammer && trick(OOT_HAMMER_WALLS)"
 "Fire Temple After Miniboss":
   dungeon: Fire
   exits:
-    "Fire Temple Pillar Ledge": "true"
+    "Fire Temple Pillar Ledge": "can_hammer"
   locations:
     "Fire Temple Hammer": "true"
-"Fire Temple Scarecrow":
-  dungeon: Fire
-  locations:
-    "Fire Temple Scarecrow Chest": "true"
-    "Fire Temple GS Scarecrow Wall": "has_ranged_weapon_adult"
-    "Fire Temple GS Scarecrow Top": "can_collect_distance"
 "Fire Temple Boss":
   boss: true
   dungeon: Fire
   exits:
-    "Fire Temple After Boss": "can_hammer"
+    "Fire Temple After Boss": "can_hammer && has_tunic_goron_strict"
 "Fire Temple After Boss":
   boss: true
   dungeon: Fire

--- a/data/oot/world/fire_temple.yml
+++ b/data/oot/world/fire_temple.yml
@@ -16,50 +16,27 @@
 "Fire Temple Lava Room":
   dungeon: Fire
   exits:
-    "Fire Temple After Elevator": "has_small_keys_fire(3) && has_tunic_goron_strict"
+    "Fire Temple Maze": "has_small_keys_fire(3) && has_tunic_goron_strict && has(STRENGTH) && (has_ranged_weapon_adult || has_explosives)"
   locations:
     "Fire Temple Jail 2 Chest": "has_tunic_goron"
     "Fire Temple Jail 3 Chest": "has_tunic_goron && has_explosives"
     "Fire Temple GS Lava Side Room": "has_tunic_goron && can_play(SONG_TIME)"
-"Fire Temple After Elevator":
-  dungeon: Fire
-  exits:
-    "Fire Temple Maze": "has(STRENGTH) && (has_ranged_weapon_adult || has_explosives)"
-    "Fire Temple Ring": "has_small_keys_fire(6)"
-    "Fire Temple Scarecrow": "has_small_keys_fire(5) && scarecrow_hookshot"
-  locations:
-    "Fire Temple Maze Chest": "true"
-    "Fire Temple Jail 4 Chest": "true"
-    "Fire Temple Map": "has_small_keys_fire(4) && (can_use_bow || has_small_keys_fire(5))"
-    "Fire Temple Above Maze Chest": "has_small_keys_fire(5)"
-    "Fire Temple Below Maze Chest": "has_small_keys_fire(5) && has_explosives"
-    "Fire Temple GS Maze": "has_explosives"
 "Fire Temple Maze":
   dungeon: Fire
   exits:
-    "Fire Temple Before Map": "has_small_keys_fire(4)"
+    "Fire Temple Maze Upper": "has_small_keys_fire(5)"
   locations:
     "Fire Temple Maze Chest": "true"
     "Fire Temple Jail 4 Chest": "true"
     "Fire Temple GS Maze": "has_explosives"
-"Fire Temple Before Map":
-  dungeon: Fire
-  exits:
-    "Fire Temple Flame Wall": "has_small_keys_fire(5)"
-  locations:
-    "Fire Temple Map": "can_use_bow"
-"Fire Temple Flame Wall":
-  dungeon: Fire
-  exits:
-    "Fire Temple Ring": "has_small_keys_fire(6)"
-    "Fire Temple Maze Upper": "scarecrow_hookshot"
-  locations:
-    "Fire Temple Map": "true"
+    "Fire Temple Map": "can_use_bow && has_small_keys_fire(4)"
 "Fire Temple Maze Upper":
   dungeon: Fire
   exits:
+    "Fire Temple Ring": "has_small_keys_fire(6)"
     "Fire Temple Scarecrow": "scarecrow_hookshot"
   locations:
+    "Fire Temple Map": "true"
     "Fire Temple Above Maze Chest": "true"
     "Fire Temple Below Maze Chest": "has_explosives"
 "Fire Temple Scarecrow":

--- a/data/oot/world/gerudo_fortress.yml
+++ b/data/oot/world/gerudo_fortress.yml
@@ -3,10 +3,10 @@
   exits:
     "Gerudo Fortress Exterior": "true"
   events:
-    CARPENTERS_RESCUE: "has(SMALL_KEY_GF, 4) && (can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD))"
+    CARPENTERS_RESCUE: "has_weapon && has(SMALL_KEY_GF, 4) && (can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD))"
   locations:
-    "Gerudo Fortress Jail 1": "true"
-    "Gerudo Fortress Jail 2": "true"
-    "Gerudo Fortress Jail 3": "true"
-    "Gerudo Fortress Jail 4": "can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD)"
+    "Gerudo Fortress Jail 1": "has_weapon"
+    "Gerudo Fortress Jail 2": "has_weapon"
+    "Gerudo Fortress Jail 3": "has_weapon"
+    "Gerudo Fortress Jail 4": "has_weapon && (can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD))"
     "Gerudo Member Card": "event(CARPENTERS_RESCUE)"

--- a/data/oot/world/gerudo_fortress.yml
+++ b/data/oot/world/gerudo_fortress.yml
@@ -3,7 +3,7 @@
   exits:
     "Gerudo Fortress Exterior": "true"
   events:
-    CARPENTERS_RESCUE: "has(SMALL_KEY_GF, 4)"
+    CARPENTERS_RESCUE: "has(SMALL_KEY_GF, 4) && (can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD))"
   locations:
     "Gerudo Fortress Jail 1": "true"
     "Gerudo Fortress Jail 2": "true"

--- a/data/oot/world/gerudo_training_grounds.yml
+++ b/data/oot/world/gerudo_training_grounds.yml
@@ -39,7 +39,7 @@
 "Gerudo Training Grounds Lava":
   dungeon: GTG
   exits:
-    "Gerudo Training Grounds Maze Side": "can_play(SONG_TIME)"
+    "Gerudo Training Grounds Maze Side": "can_play(SONG_TIME) || is_child"
     "Gerudo Training Grounds Hammer": "can_hookshot && (can_longshot || has_hover_boots || can_play(SONG_TIME))"
     "Gerudo Training Grounds Water": "can_hookshot && (has_hover_boots || can_play(SONG_TIME))"
 "Gerudo Training Grounds Maze Side":
@@ -74,3 +74,6 @@
     "Gerudo Training Maze Chest 2": "has(SMALL_KEY_GTG, 6)"
     "Gerudo Training Maze Chest 3": "has(SMALL_KEY_GTG, 7)"
     "Gerudo Training Maze Chest 4": "has(SMALL_KEY_GTG, 9)"
+    "Gerudo Training Freestanding Key": "has(SMALL_KEY_GTG, 9)"
+    "Gerudo Training Maze Side Chest 1": "has(SMALL_KEY_GTG, 9)"
+    "Gerudo Training Maze Side Chest 2": "has(SMALL_KEY_GTG, 9)"

--- a/data/oot/world/gerudo_training_grounds.yml
+++ b/data/oot/world/gerudo_training_grounds.yml
@@ -44,6 +44,8 @@
     "Gerudo Training Grounds Water": "can_hookshot && (has_hover_boots || can_play(SONG_TIME))"
 "Gerudo Training Grounds Maze Side":
   dungeon: GTG
+  exits:
+    "Gerudo Training Grounds Maze Side": "true"
   locations:
     "Gerudo Training Freestanding Key": "true"
     "Gerudo Training Maze Side Chest 1": "true"
@@ -69,7 +71,7 @@
 "Gerudo Training Grounds Maze":
   dungeon: GTG
   exits:
-    "Gerudo Training Grounds Lava": "has(SMALL_KEY_GTG, 9)"
+    "Gerudo Training Grounds Maze Side": "has(SMALL_KEY_GTG, 9)"
   locations:
     "Gerudo Training Maze Upper Fake Ceiling": "has(SMALL_KEY_GTG, 3) && has_lens"
     "Gerudo Training Maze Chest 1": "has(SMALL_KEY_GTG, 4)"

--- a/data/oot/world/gerudo_training_grounds.yml
+++ b/data/oot/world/gerudo_training_grounds.yml
@@ -68,12 +68,11 @@
     "Gerudo Training Grounds Eye Statue": "can_use_bow"
 "Gerudo Training Grounds Maze":
   dungeon: GTG
+  exits:
+    "Gerudo Training Grounds Lava": "has(SMALL_KEY_GTG, 9)"
   locations:
     "Gerudo Training Maze Upper Fake Ceiling": "has(SMALL_KEY_GTG, 3) && has_lens"
     "Gerudo Training Maze Chest 1": "has(SMALL_KEY_GTG, 4)"
     "Gerudo Training Maze Chest 2": "has(SMALL_KEY_GTG, 6)"
     "Gerudo Training Maze Chest 3": "has(SMALL_KEY_GTG, 7)"
     "Gerudo Training Maze Chest 4": "has(SMALL_KEY_GTG, 9)"
-    "Gerudo Training Freestanding Key": "has(SMALL_KEY_GTG, 9)"
-    "Gerudo Training Maze Side Chest 1": "has(SMALL_KEY_GTG, 9)"
-    "Gerudo Training Maze Side Chest 2": "has(SMALL_KEY_GTG, 9)"

--- a/data/oot/world/gerudo_training_grounds.yml
+++ b/data/oot/world/gerudo_training_grounds.yml
@@ -45,7 +45,7 @@
 "Gerudo Training Grounds Maze Side":
   dungeon: GTG
   exits:
-    "Gerudo Training Grounds Maze Side": "true"
+    "Gerudo Training Grounds Lava": "true"
   locations:
     "Gerudo Training Freestanding Key": "true"
     "Gerudo Training Maze Side Chest 1": "true"

--- a/data/oot/world/jabu_jabu.yml
+++ b/data/oot/world/jabu_jabu.yml
@@ -12,9 +12,9 @@
     "Jabu-Jabu Map Chest": "can_boomerang"
     "Jabu-Jabu Compass Chest": "can_boomerang"
     "Jabu-Jabu Boomerang Chest": "true"
-    "Jabu-Jabu GS Bottom Lower": "can_boomerang"
-    "Jabu-Jabu GS Bottom Upper": "can_boomerang"
-    "Jabu-Jabu GS Water Switch": "has_ranged_weapon || has_explosives"
+    "Jabu-Jabu GS Bottom Lower": "can_collect_distance"
+    "Jabu-Jabu GS Bottom Upper": "can_collect_distance"
+    "Jabu-Jabu GS Water Switch": "true"
     "Jabu-Jabu GS Near Boss": "can_boomerang"
 "Jabu-Jabu Boss":
   boss: true

--- a/data/oot/world/water_temple.yml
+++ b/data/oot/world/water_temple.yml
@@ -10,7 +10,7 @@
     "Water Temple Ruto Room": "has_tunic_zora && has_iron_boots || event(WATER_LEVEL_LOW)"
     "Water Temple Center Bottom": "event(WATER_LEVEL_LOW) && has(SMALL_KEY_WATER, 5)"
     "Water Temple Center Middle": "event(WATER_LEVEL_LOW) && (can_use_din || can_use_bow)"
-    "Water Temple Compass Room": "has_tunic_zora && has_iron_boots && can_hookshot"
+    "Water Temple Compass Room": "has_tunic_zora && (has_iron_boots || event(WATER_LEVEL_LOW) && can_hookshot"
     "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has(STRENGTH) && can_dive_small"
     "Water Temple Elevator": "(has(SMALL_KEY_WATER, 5) && can_hookshot) || can_use_bow || can_use_din"
     "Water Temple Corridor": "(can_longshot || has_hover_boots) && can_use_bow && event(WATER_LEVEL_LOW)"

--- a/data/oot/world/water_temple.yml
+++ b/data/oot/world/water_temple.yml
@@ -7,16 +7,17 @@
   dungeon: Water
   exits:
     "Water Temple": "true"
-    "Water Temple Ruto Room": "has_iron_boots"
-    "Water Temple Center": "event(WATER_LEVEL_LOW) && (has(SMALL_KEY_WATER, 5) || can_use_din || can_use_bow)"
-    "Water Temple Compass Room": "(can_play(SONG_ZELDA) || has_iron_boots) && can_hookshot"
-    "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has(STRENGTH)"
-    "Water Temple Elevator": "has(SMALL_KEY_WATER, 5) || can_use_din || can_use_bow"
+    "Water Temple Ruto Room": "has_tunic_zora && has_iron_boots || event(WATER_LEVEL_LOW)"
+    "Water Temple Center Bottom": "event(WATER_LEVEL_LOW) && has(SMALL_KEY_WATER, 5)"
+    "Water Temple Center Middle": "event(WATER_LEVEL_LOW) && (can_use_din || can_use_bow)"
+    "Water Temple Compass Room": "has_tunic_zora && has_iron_boots && can_hookshot"
+    "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has(STRENGTH) && can_dive_small"
+    "Water Temple Elevator": "event(WATER_LEVEL_MIDDLE)"
     "Water Temple Corridor": "(can_longshot || has_hover_boots) && can_use_bow && event(WATER_LEVEL_LOW)"
-    "Water Temple Waterfalls": "has(SMALL_KEY_WATER, 4) && can_longshot && has_iron_boots"
+    "Water Temple Waterfalls": "has_tunic_zora && has(SMALL_KEY_WATER, 4) && can_longshot && has_iron_boots"
     "Water Temple Large Pit": "has(SMALL_KEY_WATER, 4) && event(WATER_LEVEL_RESET)"
     "Water Temple Antichamber": "can_longshot && event(WATER_LEVEL_RESET)"
-    "Water Temple Cage Room": "event(WATER_LEVEL_LOW) && has_explosives && has_iron_boots"
+    "Water Temple Cage Room": "event(WATER_LEVEL_LOW) && has_explosives && can_dive_small"
     "Water Temple Main Ledge": "has_hover_boots"
 "Water Temple Main Ledge":
   dungeon: Water
@@ -32,7 +33,7 @@
   events:
     WATER_LEVEL_LOW: "can_play(SONG_ZELDA)"
   locations:
-    "Water Temple Bombable Chest": "event(WATER_LEVEL_MIDDLE) && has_explosives"
+    "Water Temple Bombable Chest": "(event(WATER_LEVEL_MIDDLE) || has_hover_boots) && has_explosives"
 "Water Temple Map Room":
   dungeon: Water
   locations:
@@ -41,14 +42,19 @@
   dungeon: Water
   locations:
     "Water Temple Shell Chest": "true"
-"Water Temple Center":
+"Water Temple Center Bottom":
   dungeon: Water
   exits:
     "Water Temple Under Center": "event(WATER_LEVEL_MIDDLE) && has_iron_boots && has_tunic_zora_strict"
+    "Water Temple Center Middle": "can_hookshot"
+"Water Temple Center Middle":
+  dungeon: Water
+  exits:
+    "Water Temple Center Bottom": "true"
   events:
-    WATER_LEVEL_MIDDLE: "can_hookshot && can_play(SONG_ZELDA)"
+    WATER_LEVEL_MIDDLE: "can_play(SONG_ZELDA)"
   locations:
-    "Water Temple GS Center": "event(WATER_LEVEL_MIDDLE) && can_longshot"
+    "Water Temple GS Center": "can_longshot"
 "Water Temple Under Center":
   dungeon: Water
   locations:
@@ -56,7 +62,7 @@
 "Water Temple Compass Room":
   dungeon: Water
   locations:
-    "Water Temple Compass": "can_hookshot"
+    "Water Temple Compass": "true"
 "Water Temple Dragon Room":
   dungeon: Water
   locations:
@@ -68,7 +74,7 @@
 "Water Temple Corridor":
   dungeon: Water
   locations:
-    "Water Temple Corridor Chest": "true"
+    "Water Temple Corridor Chest": "has(STRENGTH)"
 "Water Temple Waterfalls":
   dungeon: Water
   exits:
@@ -114,11 +120,11 @@
     "Water Temple Dragon Room": "can_use_bow"
   locations:
     "Water Temple River Chest": "can_use_bow"
-    "Water Temple GS River": "can_longshot"
+    "Water Temple GS River": "has_iron_boots"
 "Water Temple Cage Room":
   dungeon: Water
   locations:
-    "Water Temple GS Cage": "can_hookshot"
+    "Water Temple GS Cage": "can_hookshot || has_hover_boots"
 "Water Temple Antichamber":
   dungeon: Water
   exits:

--- a/data/oot/world/water_temple.yml
+++ b/data/oot/world/water_temple.yml
@@ -10,7 +10,7 @@
     "Water Temple Ruto Room": "has_tunic_zora && has_iron_boots || event(WATER_LEVEL_LOW)"
     "Water Temple Center Bottom": "event(WATER_LEVEL_LOW) && has(SMALL_KEY_WATER, 5)"
     "Water Temple Center Middle": "event(WATER_LEVEL_LOW) && (can_use_din || can_use_bow)"
-    "Water Temple Compass Room": "has_tunic_zora && (has_iron_boots || event(WATER_LEVEL_LOW) && can_hookshot"
+    "Water Temple Compass Room": "has_tunic_zora && (has_iron_boots || event(WATER_LEVEL_LOW)) && can_hookshot"
     "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has(STRENGTH) && can_dive_small"
     "Water Temple Elevator": "(has(SMALL_KEY_WATER, 5) && can_hookshot) || can_use_bow || can_use_din"
     "Water Temple Corridor": "(can_longshot || has_hover_boots) && can_use_bow && event(WATER_LEVEL_LOW)"

--- a/data/oot/world/water_temple.yml
+++ b/data/oot/world/water_temple.yml
@@ -12,7 +12,7 @@
     "Water Temple Center Middle": "event(WATER_LEVEL_LOW) && (can_use_din || can_use_bow)"
     "Water Temple Compass Room": "has_tunic_zora && has_iron_boots && can_hookshot"
     "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has(STRENGTH) && can_dive_small"
-    "Water Temple Elevator": "event(WATER_LEVEL_MIDDLE)"
+    "Water Temple Elevator": "(has(SMALL_KEY_WATER, 5) && can_hookshot) || can_use_bow || can_use_din"
     "Water Temple Corridor": "(can_longshot || has_hover_boots) && can_use_bow && event(WATER_LEVEL_LOW)"
     "Water Temple Waterfalls": "has_tunic_zora && has(SMALL_KEY_WATER, 4) && can_longshot && has_iron_boots"
     "Water Temple Large Pit": "has(SMALL_KEY_WATER, 4) && event(WATER_LEVEL_RESET)"

--- a/data/oot/world/water_temple.yml
+++ b/data/oot/world/water_temple.yml
@@ -7,10 +7,10 @@
   dungeon: Water
   exits:
     "Water Temple": "true"
-    "Water Temple Ruto Room": "has_tunic_zora && has_iron_boots || event(WATER_LEVEL_LOW)"
+    "Water Temple Ruto Room": "(has_tunic_zora && has_iron_boots) || event(WATER_LEVEL_LOW)"
     "Water Temple Center Bottom": "event(WATER_LEVEL_LOW) && has(SMALL_KEY_WATER, 5)"
     "Water Temple Center Middle": "event(WATER_LEVEL_LOW) && (can_use_din || can_use_bow)"
-    "Water Temple Compass Room": "has_tunic_zora && (has_iron_boots || event(WATER_LEVEL_LOW)) && can_hookshot"
+    "Water Temple Compass Room": "((has_tunic_zora && has_iron_boots) || event(WATER_LEVEL_LOW)) && can_hookshot"
     "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has(STRENGTH) && can_dive_small"
     "Water Temple Elevator": "(has(SMALL_KEY_WATER, 5) && can_hookshot) || can_use_bow || can_use_din"
     "Water Temple Corridor": "(can_longshot || has_hover_boots) && can_use_bow && event(WATER_LEVEL_LOW)"

--- a/data/oot/world/water_temple.yml
+++ b/data/oot/world/water_temple.yml
@@ -33,7 +33,7 @@
   events:
     WATER_LEVEL_LOW: "can_play(SONG_ZELDA)"
   locations:
-    "Water Temple Bombable Chest": "(event(WATER_LEVEL_MIDDLE) || has_hover_boots) && has_explosives"
+    "Water Temple Bombable Chest": "event(WATER_LEVEL_MIDDLE) && has_explosives"
 "Water Temple Map Room":
   dungeon: Water
   locations:


### PR DESCRIPTION
Logic now accounts for accessing dungeons as both ages. It also fixes some logic errors found in some parts. Gerudo Fortress now also properly checks for the requirements for the 4th carpenter to get the Gerudo Card check.