### PR TITLE
Fix some GF hint stuff

### DIFF
--- a/data/mm/world/woodfall_temple.yml
+++ b/data/mm/world/woodfall_temple.yml
@@ -109,7 +109,7 @@
     "Woodfall Temple SF Pre-Boss Bottom Right": "true"
     "Woodfall Temple SF Pre-Boss Left": "has(MASK_DEKU) || has(MASK_GREAT_FAIRY)"
     "Woodfall Temple SF Pre-Boss Top Right": "true"
-    "Woodfall Temple SF Pre-Boss Pillar": "has(MASK_DEKU) && has(BOW)"
+    "Woodfall Temple SF Pre-Boss Pillar": "has(MASK_DEKU) || has(MASK_GREAT_FAIRY)"
 "Woodfall Temple Princess Jail":
   dungeon: WF
   events:

--- a/lib/combo/logic/analysis.ts
+++ b/lib/combo/logic/analysis.ts
@@ -191,9 +191,18 @@ const SIMPLE_DEPENDENCIES: {[k: string]: string[]} = {
   ],
   MM_MASK_GREAT_FAIRY: [
     'MM Moon Fierce Deity Mask',
-    'MM Woodfall Great Fairy',
-    'MM Snowhead Great Fairy',
-    'MM Great Bay Great Fairy',
+    'MM Woodfall Temple SF Water Room Beehive',
+    'MM Woodfall Temple SF Maze Bubble',
+    'MM Woodfall Temple SF Pre-Boss Left',
+    'MM Woodfall Temple SF Pre-Boss Pillar',
+    'MM Snowhead Temple SF Bridge Pillar',
+    'MM Snowhead Temple SF Bridge Under Platform',
+    'MM Snowhead Temple SF Compass Room Crate',
+    'MM Snowhead Temple SF Dual Switches',
+    'MM Snowhead Temple SF Snow Room',
+    'MM Great Bay Temple SF Water Wheel Platform',
+    'MM Great Bay Temple SF Central Room Underwater Pot',
+    //'MM Great Bay Temple SF Pre-Boss Above Water', #Uncomment this if a trick to reverse the water flow in Great Bay Temple without Ice Arrows is added.
   ],
   MM_MASK_DON_GERO: [
     'MM Moon Fierce Deity Mask',


### PR DESCRIPTION
This fixes an issue in which the GF Mask could erroneously be labeled as foolish when it was not in fairysanity. It will currently be a bit overbroad in what it handles as it's built to be ER safe. I also fix a very minor logic issue with one of the fairies in Woodfall Temple that should only come up