### PR TITLE
Fix spawn after beating the temples at Stone Tower.

### DIFF
--- a/src/common/warp.c
+++ b/src/common/warp.c
@@ -120,7 +120,7 @@ void comboTriggerWarp(GameState_Play* play, int bossId)
     case DUNGEONID_TEMPLE_STONE_TOWER:
     case DUNGEONID_TEMPLE_STONE_TOWER_INVERTED:
         isMmEntrance = 1;
-        entrance = 0x20f0;
+        entrance = 0x2070;
         break;
     case DUNGEONID_SPIDER_HOUSE_SWAMP:
         isMmEntrance = 1;


### PR DESCRIPTION
This spawns you up between the cave, the music box house and the exit to stone tower. There's no "slowly falling from the sky" cutscene though, because triggering that cutscene causes the area loaded to be cleared ikana (no gibdos; music box house unlocked; etc).