### PR TITLE
Fix post-dungeon-clear link spawn flags

### DIFF
--- a/src/common/warp.c
+++ b/src/common/warp.c
@@ -110,7 +110,7 @@ void comboTriggerWarp(GameState_Play* play, int bossId)
         }
         else
         {
-            entrance = 0x9a80;
+            entrance = 0x9a70;
         }
         break;
     case DUNGEONID_TEMPLE_GREAT_BAY:

--- a/src/mm/scenes/z2_10yukiyamanomura_scene.S
+++ b/src/mm/scenes/z2_10yukiyamanomura_scene.S
@@ -1,0 +1,6 @@
+#include <combo.h>
+
+/* Post-dungeon-clear link spawn flags */
+PATCH_VROM 0x02A97000 + 0x10E
+.byte 0x02
+PATCH_END

--- a/src/mm/scenes/z2_ikana_scene.S
+++ b/src/mm/scenes/z2_ikana_scene.S
@@ -1,0 +1,11 @@
+#include <combo.h>
+
+/* Cursed Ikana post-dungeon-clear link spawn flags */
+PATCH_VROM 0x02036000 + 0x12E
+.byte 0x02
+PATCH_END
+
+/* Cleared Ikana post-dungeon-clear link spawn flags */
+PATCH_VROM 0x02036000 + 0x145C6
+.byte 0x02
+PATCH_END


### PR DESCRIPTION
Fix post-dungeon-clear link spawn flags in Mountain Village Winter, Ikana Canyon Cursed and Ikana Canyon Cleared.