### PR TITLE
Another MQ DC logic issue

### DIFF
--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -36,7 +36,6 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Upper Ledges": "can_use_sticks || has_weapon || can_use_slingshot"
-    "Dodongo Cavern Lower Lizalfos": "has_explosives_or_hammer"
   locations:
     "MQ Dodongo Cavern GS Upper Lizalfos": "has_explosives_or_hammer"
 "Dodongo Cavern Upper Ledges":


### PR DESCRIPTION
Jumping down fails to spawn the Lizalfos properly, softlocking the player if they weren't already cleared. Who knew? This accounts for that. Hopefully this is the last such problem.