### PR TITLE
Logic Review for Child Dungeons - Do Not Merge

### DIFF
--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -15,7 +15,7 @@
   locations:
     "MQ Deku Tree Map Chest": "true"
     "MQ Deku Tree Slingshot Chest": "has_weapon || can_use_sticks || has_ranged_weapon_child" #Bombs and Din's work, but it's horrible.
-    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow"
+    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow" # yeah, this is not that intuitive
     "MQ Deku Tree Basement Chest": "has_fire_or_sticks || can_use_bow"
     "MQ Deku Tree GS Lobby Crate": "can_damage_skull"
 "Deku Tree Compass Room":

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -15,7 +15,7 @@
   locations:
     "MQ Deku Tree Map Chest": "true"
     "MQ Deku Tree Slingshot Chest": "has_weapon || can_use_sticks || has_ranged_weapon_child" #Bombs and Din's work, but it's horrible.
-    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire"
+    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow"
     "MQ Deku Tree Basement Chest": "has_fire_or_sticks || can_use_bow"
     "MQ Deku Tree GS Lobby Crate": "can_damage_skull"
 "Deku Tree Compass Room":
@@ -24,7 +24,7 @@
     "Deku Tree Lobby": "true"
   locations:
     "MQ Deku Tree Compass Chest": "true"
-    "MQ Deku Tree GS Compass Room": "has_explosives && can_collect_distance"
+    "MQ Deku Tree GS Compass Room": "(can_collect_distance) && (has_explosives || (can_hammer && can_play(SONG_TIME)))"
 "Deku Tree Water Room":
   dungeon: DT
   exits:

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -24,7 +24,7 @@
     "Deku Tree Lobby": "true"
   locations:
     "MQ Deku Tree Compass Chest": "true"
-    "MQ Deku Tree GS Compass Room": (can_hookshot || can_boomerang) && (has_explosives || (can_hammer && can_play(SONG_TIME)))
+    "MQ Deku Tree GS Compass Room": (can_collect_distance) && (has_explosives || (can_hammer && can_play(SONG_TIME)))
 "Deku Tree Water Room":
   dungeon: DT
   exits:

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -24,12 +24,12 @@
     "Deku Tree Lobby": "true"
   locations:
     "MQ Deku Tree Compass Chest": "true"
-    "MQ Deku Tree GS Compass Room": (can_collect_distance) && (has_explosives || (can_hammer && can_play(SONG_TIME)))
+    "MQ Deku Tree GS Compass Room": "(can_collect_distance) && (has_explosives || (can_hammer && can_play(SONG_TIME)))"
 "Deku Tree Water Room":
   dungeon: DT
   exits:
     "Deku Tree Lobby": "true"
-    "Deku Tree Water Room Back": "(is_child && (has(SHIELD_DEKU) || has(SHIELD_HYLIAN) || can_longshot || (can_hookshot && has_iron_boots)"
+    "Deku Tree Water Room Back": "(is_child && (has(SHIELD_DEKU) || has(SHIELD_HYLIAN))) || can_longshot || (can_hookshot && has_iron_boots)"
   locations:
     "MQ Deku Tree Before Water Platform Chest": "true"
 "Deku Tree Water Room Back":
@@ -46,7 +46,7 @@
     "Deku Tree Basement Ledge": "can_use_sticks || can_use_din"
   locations:
     "MQ Deku Tree GS Song of Time Blocks": "(can_play(SONG_TIME) && can_collect_distance) || can_longshot"
-    "MQ Deku Tree GS Back Room": "(has_fire_or_sticks) && can_collect_distance"
+    "MQ Deku Tree GS Back Room": "has_fire_or_sticks && can_collect_distance"
 "Deku Tree Basement Ledge":
   dungeon: DT
   exits:

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -15,8 +15,8 @@
   locations:
     "MQ Deku Tree Map Chest": "true"
     "MQ Deku Tree Slingshot Chest": "has_weapon || can_use_sticks || has_ranged_weapon_child" #Bombs and Din's work, but it's horrible.
-    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow" # I think this bow angle is quite intuitive
-    "MQ Deku Tree Basement Chest": "has_fire_or_sticks" # || can_bow, but the angle is quite strict
+    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow"
+    "MQ Deku Tree Basement Chest": "has_fire_or_sticks || can_use_bow"
     "MQ Deku Tree GS Lobby Crate": "can_damage_skull"
 "Deku Tree Compass Room":
   dungeon: DT
@@ -24,19 +24,12 @@
     "Deku Tree Lobby": "true"
   locations:
     "MQ Deku Tree Compass Chest": "true"
-    "MQ Deku Tree GS Compass Room": (can_hookshot || can_boomerang) && (has_bombchu || (has_explosives && (is_adult || can_play(SONG_TIME))) || (can_hammer && can_play(SONG_TIME)))
-    # in more readable format:
-    # (hook || boomerang) && (chus || (bomb && (adult || time)) || (hammer && time))
-    # even more readable:
-    # *(collect) && (destroyBoulders)
+    "MQ Deku Tree GS Compass Room": (can_hookshot || can_boomerang) && (has_explosives || (can_hammer && can_play(SONG_TIME)))
 "Deku Tree Water Room":
   dungeon: DT
   exits:
     "Deku Tree Lobby": "true"
-    "Deku Tree Water Room Back": "is_child || can_longshot || (can_hookshot && has_iron_boots)"
-    # We should consider this:
-    # "Deku Tree Water Room Back": "(is_child && (has(SHIELD_DEKU) || has(SHIELD_HYLIAN) || can_longshot || (can_hookshot && has_iron_boots)"
-    # as rolling below the log might not be as intuitive. If so, crouching with either shield is a better option.
+    "Deku Tree Water Room Back": "(is_child && (has(SHIELD_DEKU) || has(SHIELD_HYLIAN) || can_longshot || (can_hookshot && has_iron_boots)"
   locations:
     "MQ Deku Tree Before Water Platform Chest": "true"
 "Deku Tree Water Room Back":
@@ -45,6 +38,7 @@
     "Deku Tree Backrooms": "has_fire_or_sticks"
   locations:
     "MQ Deku Tree After Water Platform Chest": "can_play(SONG_TIME)"
+    "MQ Deku Tree Before Water Platform Chest": "true"
 "Deku Tree Backrooms":
   dungeon: DT
   exits:
@@ -59,7 +53,7 @@
     "Deku Tree Before Boss": "has_fire_or_sticks"
     "Deku Tree Backrooms": "is_child"
   events:
-    DEKU_BLOCK: "true" # Either I don't understand this event, or it is [currently] unnecessary
+    DEKU_BLOCK: "true"
   #locations:
     #"MQ Deku Tree Scrub": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
 "Deku Tree Before Boss":

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -15,8 +15,8 @@
   locations:
     "MQ Deku Tree Map Chest": "true"
     "MQ Deku Tree Slingshot Chest": "has_weapon || can_use_sticks || has_ranged_weapon_child" #Bombs and Din's work, but it's horrible.
-    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow" # I think bow is easy here
-    "MQ Deku Tree Basement Chest": "has_fire_or_sticks" # has_fire_or_sticks || can_bow but you need a precise angle
+    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow" # I think this bow angle is quite intuitive
+    "MQ Deku Tree Basement Chest": "has_fire_or_sticks" # || can_bow, but the angle is quite strict
     "MQ Deku Tree GS Lobby Crate": "can_damage_skull"
 "Deku Tree Compass Room":
   dungeon: DT
@@ -25,15 +25,18 @@
   locations:
     "MQ Deku Tree Compass Chest": "true"
     "MQ Deku Tree GS Compass Room": (can_hookshot || can_boomerang) && (has_bombchu || (has_explosives && (is_adult || can_play(SONG_TIME))) || (can_hammer && can_play(SONG_TIME)))
+    # in more readable format:
     # (hook || boomerang) && (chus || (bomb && (adult || time)) || (hammer && time))
+    # even more readable:
     # *(collect) && (destroyBoulders)
 "Deku Tree Water Room":
   dungeon: DT
   exits:
     "Deku Tree Lobby": "true"
     "Deku Tree Water Room Back": "is_child || can_longshot || (can_hookshot && has_iron_boots)"
+    # We should consider this:
     # "Deku Tree Water Room Back": "(is_child && (has(SHIELD_DEKU) || has(SHIELD_HYLIAN) || can_longshot || (can_hookshot && has_iron_boots)"
-    # Rolling below the log might not be as intuitive, if so crouching with shield is a better option.
+    # as rolling below the log might not be as intuitive. If so, crouching with either shield is a better option.
   locations:
     "MQ Deku Tree Before Water Platform Chest": "true"
 "Deku Tree Water Room Back":
@@ -56,7 +59,7 @@
     "Deku Tree Before Boss": "has_fire_or_sticks"
     "Deku Tree Backrooms": "is_child"
   events:
-    DEKU_BLOCK: "true" # I think this is unnecessary?
+    DEKU_BLOCK: "true" # Either I don't understand this event, or it is [currently] unnecessary
   #locations:
     #"MQ Deku Tree Scrub": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
 "Deku Tree Before Boss":

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -7,7 +7,7 @@
   dungeon: DT
   exits:
     "Deku Tree Compass Room": "can_use_bow || (can_use_slingshot && (can_use_sticks || can_use_din))"
-    "Deku Tree Water Room": "(can_use_slingshot || can_use_bow) && (can_use_sticks || has_fire)"
+    "Deku Tree Water Room": "can_hit_triggers_distance && has_fire_or_sticks"
     "Deku Tree Basement Ledge": "is_adult || event(DEKU_BLOCK) || trick(OOT_DEKU_SKIP)"
   events:
     STICKS: "has_weapon || can_boomerang"
@@ -15,8 +15,8 @@
   locations:
     "MQ Deku Tree Map Chest": "true"
     "MQ Deku Tree Slingshot Chest": "has_weapon || can_use_sticks || has_ranged_weapon_child" #Bombs and Din's work, but it's horrible.
-    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire"
-    "MQ Deku Tree Basement Chest": "can_use_sticks || has_fire"
+    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow" # I think bow is easy here
+    "MQ Deku Tree Basement Chest": "has_fire_or_sticks" # has_fire_or_sticks || can_bow but you need a precise angle
     "MQ Deku Tree GS Lobby Crate": "can_damage_skull"
 "Deku Tree Compass Room":
   dungeon: DT
@@ -24,21 +24,22 @@
     "Deku Tree Lobby": "true"
   locations:
     "MQ Deku Tree Compass Chest": "true"
-    "MQ Deku Tree GS Compass Room": "has_explosives && can_collect_distance"
+    "MQ Deku Tree GS Compass Room": (can_hookshot || can_boomerang) && (has_bombchu || (has_explosives && (is_adult || can_play(SONG_TIME))) || (can_hammer && can_play(SONG_TIME)))
+    # (hook || boomerang) && (chus || (bomb && (adult || time)) || (hammer && time))
+    # *(collect) && (destroyBoulders)
 "Deku Tree Water Room":
   dungeon: DT
   exits:
     "Deku Tree Lobby": "true"
-    "Deku Tree Water Room Back": "is_child || can_longshot || (can_hookshot && has_iron_boots)"
+    "Deku Tree Water Room Back": "is_child || can_longshot || (can_hookshot && has_iron_boots)" # is_child also requires deku or hylian shield, if you consider rolling a trick
   locations:
     "MQ Deku Tree Before Water Platform Chest": "true"
 "Deku Tree Water Room Back":
   dungeon: DT
   exits:
-    "Deku Tree Backrooms": "can_use_sticks || has_fire"
+    "Deku Tree Backrooms": "has_fire_or_sticks"
   locations:
     "MQ Deku Tree After Water Platform Chest": "can_play(SONG_TIME)"
-    "MQ Deku Tree Before Water Platform Chest": "true"
 "Deku Tree Backrooms":
   dungeon: DT
   exits:
@@ -46,14 +47,14 @@
     "Deku Tree Basement Ledge": "can_use_sticks || can_use_din"
   locations:
     "MQ Deku Tree GS Song of Time Blocks": "(can_play(SONG_TIME) && can_collect_distance) || can_longshot"
-    "MQ Deku Tree GS Back Room": "(can_use_sticks || has_fire) && can_collect_distance"
+    "MQ Deku Tree GS Back Room": "(has_fire_or_sticks) && can_collect_distance"
 "Deku Tree Basement Ledge":
   dungeon: DT
   exits:
-    "Deku Tree Before Boss": "can_use_sticks || has_fire"
+    "Deku Tree Before Boss": "has_fire_or_sticks"
     "Deku Tree Backrooms": "is_child"
   events:
-    DEKU_BLOCK: "true"
+    DEKU_BLOCK: "true" # I think this is unnecessary?
   #locations:
     #"MQ Deku Tree Scrub": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
 "Deku Tree Before Boss":

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -31,7 +31,9 @@
   dungeon: DT
   exits:
     "Deku Tree Lobby": "true"
-    "Deku Tree Water Room Back": "is_child || can_longshot || (can_hookshot && has_iron_boots)" # is_child also requires deku or hylian shield, if you consider rolling a trick
+    "Deku Tree Water Room Back": "is_child || can_longshot || (can_hookshot && has_iron_boots)"
+    # "Deku Tree Water Room Back": "(is_child && (has(SHIELD_DEKU) || has(SHIELD_HYLIAN) || can_longshot || (can_hookshot && has_iron_boots)"
+    # Rolling below the log might not be as intuitive, if so crouching with shield is a better option.
   locations:
     "MQ Deku Tree Before Water Platform Chest": "true"
 "Deku Tree Water Room Back":

--- a/data/oot/world_mq/deku_tree_mq.yml
+++ b/data/oot/world_mq/deku_tree_mq.yml
@@ -15,7 +15,7 @@
   locations:
     "MQ Deku Tree Map Chest": "true"
     "MQ Deku Tree Slingshot Chest": "has_weapon || can_use_sticks || has_ranged_weapon_child" #Bombs and Din's work, but it's horrible.
-    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire || can_use_bow" # yeah, this is not that intuitive
+    "MQ Deku Tree Slingshot Room Far Chest": "can_use_sticks || has_fire"
     "MQ Deku Tree Basement Chest": "has_fire_or_sticks || can_use_bow"
     "MQ Deku Tree GS Lobby Crate": "can_damage_skull"
 "Deku Tree Compass Room":
@@ -24,7 +24,7 @@
     "Deku Tree Lobby": "true"
   locations:
     "MQ Deku Tree Compass Chest": "true"
-    "MQ Deku Tree GS Compass Room": "(can_collect_distance) && (has_explosives || (can_hammer && can_play(SONG_TIME)))"
+    "MQ Deku Tree GS Compass Room": "has_explosives && can_collect_distance"
 "Deku Tree Water Room":
   dungeon: DT
   exits:

--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -8,7 +8,7 @@
   exits:
     "Dodongo Cavern": "true"
     "Dodongo Cavern Skull": "has_explosives"
-    "Dodongo Cavern Upper Staircase": "can_use_din || has_explosives || can_hammer || (has_bombflowers && (is_adult || can_boomerang || can_use_slingshot || can_use_sticks || has_nuts))""
+    "Dodongo Cavern Upper Staircase": "can_use_din || has_explosives || can_hammer || (has_bombflowers && (is_adult || can_boomerang || can_use_slingshot || can_use_sticks || has_nuts))"
     "Dodongo Cavern Upper Ledges": "has_explosives_or_hammer"
     "Dodongo Cavern Lower Tunnel": "has_explosives_or_hammer || event(DC_MQ_SHORTCUT)"
     "Dodongo Cavern Bomb Bag Ledge": "is_adult"

--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -16,7 +16,7 @@
     STICKS: "has_weapon || can_boomerang"
   locations:
     "MQ Dodongo Cavern Map Chest": "has_bombflowers || can_hammer"
-    "MQ Dodongo Cavern GS Time Blocks": "can_play(SONG_TIME)" # not sure about this
+    "MQ Dodongo Cavern GS Time Blocks": "can_play(SONG_TIME) && can_damage_skull"
     #"MQ Dodongo Cavern Lobby Scrub Front": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
     #"MQ Dodongo Cavern Lobby Scrub Back": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
   gossip:

--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -8,7 +8,7 @@
   exits:
     "Dodongo Cavern": "true"
     "Dodongo Cavern Skull": "has_explosives"
-    "Dodongo Cavern Upper Staircase": "has_bombflowers && (is_adult || (has_nuts || has_weapon || has_explosives || has_ranged_weapon_child))"
+    "Dodongo Cavern Upper Staircase": "can_use_din || has_explosives || has(STRENGTH) && (can_use_sticks || (has_weapon && is_child) || can_boomerang)"
     "Dodongo Cavern Upper Ledges": "has_explosives_or_hammer"
     "Dodongo Cavern Lower Tunnel": "has_explosives_or_hammer || event(DC_MQ_SHORTCUT)"
     "Dodongo Cavern Bomb Bag Ledge": "is_adult"
@@ -16,7 +16,7 @@
     STICKS: "has_weapon || can_boomerang"
   locations:
     "MQ Dodongo Cavern Map Chest": "has_bombflowers || can_hammer"
-    "MQ Dodongo Cavern GS Time Blocks": "can_play(SONG_TIME)"
+    "MQ Dodongo Cavern GS Time Blocks": "can_play(SONG_TIME) && can_damage"
     #"MQ Dodongo Cavern Lobby Scrub Front": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
     #"MQ Dodongo Cavern Lobby Scrub Back": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
   gossip:

--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -16,7 +16,7 @@
     STICKS: "has_weapon || can_boomerang"
   locations:
     "MQ Dodongo Cavern Map Chest": "has_bombflowers || can_hammer"
-    "MQ Dodongo Cavern GS Time Blocks": "can_play(SONG_TIME) && can_damage"
+    "MQ Dodongo Cavern GS Time Blocks": "can_play(SONG_TIME)" # not sure about this
     #"MQ Dodongo Cavern Lobby Scrub Front": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
     #"MQ Dodongo Cavern Lobby Scrub Back": "has_shield_for_scrub || has_ranged_weapon || can_hammer || has_nuts"
   gossip:

--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -8,7 +8,7 @@
   exits:
     "Dodongo Cavern": "true"
     "Dodongo Cavern Skull": "has_explosives"
-    "Dodongo Cavern Upper Staircase": "(has(STRENGTH) && can_use_sticks) || can_use_din || has_explosives"
+    "Dodongo Cavern Upper Staircase": "can_use_din || has_explosives || can_hammer || (has_bombflowers && (is_adult || can_boomerang || can_use_slingshot || can_use_sticks || has_nuts))""
     "Dodongo Cavern Upper Ledges": "has_explosives_or_hammer"
     "Dodongo Cavern Lower Tunnel": "has_explosives_or_hammer || event(DC_MQ_SHORTCUT)"
     "Dodongo Cavern Bomb Bag Ledge": "is_adult"

--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -8,7 +8,7 @@
   exits:
     "Dodongo Cavern": "true"
     "Dodongo Cavern Skull": "has_explosives"
-    "Dodongo Cavern Upper Staircase": "can_use_din || has_explosives || can_hammer || (has_bombflowers && (is_adult || can_boomerang || can_use_slingshot || can_use_sticks || has_nuts))"
+    "Dodongo Cavern Upper Staircase": "has_bombflowers && (is_adult || (has_nuts || has_weapon || has_explosives || has_ranged_weapon_child))"
     "Dodongo Cavern Upper Ledges": "has_explosives_or_hammer"
     "Dodongo Cavern Lower Tunnel": "has_explosives_or_hammer || event(DC_MQ_SHORTCUT)"
     "Dodongo Cavern Bomb Bag Ledge": "is_adult"
@@ -42,6 +42,7 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Upper Lizalfos": "true"
+    "Dodongo Cavern Upper Staircase": "true"
   events:
     "DC_MQ_SHORTCUT": "has_bombflowers || can_hammer"
   locations:

--- a/data/oot/world_mq/dodongo_cavern_mq.yml
+++ b/data/oot/world_mq/dodongo_cavern_mq.yml
@@ -8,7 +8,7 @@
   exits:
     "Dodongo Cavern": "true"
     "Dodongo Cavern Skull": "has_explosives"
-    "Dodongo Cavern Upper Staircase": "can_use_din || has_explosives || has(STRENGTH) && (can_use_sticks || (has_weapon && is_child) || can_boomerang)"
+    "Dodongo Cavern Upper Staircase": "(has(STRENGTH) && can_use_sticks) || can_use_din || has_explosives"
     "Dodongo Cavern Upper Ledges": "has_explosives_or_hammer"
     "Dodongo Cavern Lower Tunnel": "has_explosives_or_hammer || event(DC_MQ_SHORTCUT)"
     "Dodongo Cavern Bomb Bag Ledge": "is_adult"

--- a/data/oot/world_mq/fire_temple_mq.yml
+++ b/data/oot/world_mq/fire_temple_mq.yml
@@ -5,7 +5,7 @@
     "Fire Temple Upper Lobby": "is_adult && has_tunic_goron"
     "Fire Temple Vanilla Hammer Loop": "has(SMALL_KEY_FIRE, 5) && has_weapon && (has_explosives_or_hammer || can_hookshot)"
   locations:
-    "MQ Fire Temple Early Lower Left Chest": "has_weapon || can_use_sticks || can_use_slingshot || has_explosives || can_use_din"
+    "MQ Fire Temple Early Lower Left Chest": "can_damage"
 "Fire Temple Upper Lobby":
   dungeon: Fire
   exits:


### PR DESCRIPTION
DEKU TREE:
-couple of swaps for existing "has_fire_or_sticks" and "can_hit_triggers_distance" macros
-~~remove what I believe is a duplicate~~ not a duplicate, undone
-add Bow-only condition to "MQ Deku Tree Slingshot Room Far Chest" (that's quite tricky)
-add Bow-only condition to "MQ Deku Tree Basement Chest" (fairly intuitive, just don't stand too close)
-add an Hammer+SoT condition to "MQ Deku Tree GS Compass Room" (adds an annoying time travel case)
-add a Shield requirement to "Deku Tree Water Room Back", for crouching under the log
-~~note in the comment about DEKU_BLOCK, in case it's not just me~~ Yep, that was just me and it was fairly easy to understand


DC:
-added a damage source check for "MQ Dodongo Cavern GS Time Blocks" It's a location in "Dodongo Cavern Main", which means a Child with only Bracelet and no source of damage to kill the GS could be required to get this check (by lighting the torches, which would give him either Sticks or Din's, but that's not accounted for).
-connected "Dodongo Cavern Upper Ledges" and "Dodongo Cavern Upper Staircase" to account for backtracking. Hopefully I did it correctly.

BONUS:
A ghost commit for Fire Temple, which should already be in the branch.