### PR TITLE
Fix OoT warp song in MM instrument sound.

### DIFF
--- a/include/combo/common/api.h
+++ b/include/combo/common/api.h
@@ -171,6 +171,10 @@ void PlaySound(u16 soundId);
 void PlaySoundSpecial(u16 soundId);
 void PlayMusic(int arg0, int arg1, int arg2, int arg3, int arg4);
 
+#if defined(GAME_MM)
+void AudioOcarina_SetInstrument(u8 ocarinaInstrumentId);
+#endif
+
 int Actor_RunByteCode(Actor* this, GameState_Play* play, void* bytecode, void* unk1, void* unk2);
 void Enemy_StartFinishingBlow(GameState_Play* play, Actor* this);
 

--- a/src/link_mm.in
+++ b/src/link_mm.in
@@ -87,6 +87,7 @@ ModelViewTranslate = 0x8018029c;
 ModelViewUnkTransform = 0x801820a0;
 
 PrepareSave = 0x8014546c;
+AudioOcarina_SetInstrument = 0x8019C300;
 PlaySound = 0x8019f0c8;
 Message_Close = 0x801477b4;
 


### PR DESCRIPTION
When playing an OoT warp song in MM, the instrument sound will now turn off once the warp or error message appears.