### PR TITLE
Trick: Add two goron jumps for scrub HPs

### DIFF
--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -301,7 +301,7 @@
     FROG_3: "has(MASK_DON_GERO)"
     SWAMP_OWL: "can_play(SONG_SOARING)"
   locations:
-    "Southern Swamp HP": "has(DEED_LAND) && has(MASK_DEKU)"
+    "Southern Swamp HP": "(has(DEED_LAND) && has(MASK_DEKU)) || (trick(MM_SOUTHERN_SWAMP_SCRUB_HP_GORON) && has(MASK_GORON))"
     "Southern Swamp Scrub Deed": "has(DEED_LAND)"
     #"Southern Swamp Scrub Purchase": "has(MASK_DEKU)"
   gossip:
@@ -732,7 +732,7 @@
     "Zora Cape Peninsula": "true"
     "Zora Shop": "true"
   locations:
-    "Zora Hall Scrub HP": "has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_DEKU) && has(MASK_ZORA)"
+    "Zora Hall Scrub HP": "(has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_DEKU) && has(MASK_ZORA)) || (trick(MM_ZORA_HALL_SCRUB_HP_GORON) && has(MASK_GORON) && has(MASK_ZORA))"
     "Zora Hall Scrub Deed": "has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_ZORA)"
     #"Zora Hall Scrub Purchase": "has(MASK_ZORA)"
     "Zora Hall Evan HP": "has(MASK_ZORA) && has_ocarina"

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -464,6 +464,8 @@ export const TRICKS = {
   MM_SHT_FIRELESS: "Complete Snowhead Temple without Fire Arrows",
   MM_KEG_EXPLOSIVES: "Use Powder Kegs as Explosives",
   MM_DOG_RACE_CHEST_NOTHING: "Doggy Racetrack Chest with Nothing",
+  MM_SOUTHERN_SWAMP_SCRUB_HP_GORON: "Southern Swamp Scrub HP as Goron",
+  MM_ZORA_HALL_SCRUB_HP_GORON: "Zora Hall Scrub HP as Goron",
 };
 
 export type Tricks = {[k in keyof typeof TRICKS]: boolean};


### PR DESCRIPTION
Adds two goron jumps as tricks, one for the southern swamp scrub HP and the other for the zora hall scrub HP.

https://user-images.githubusercontent.com/42477864/228504407-8eaae6fd-8149-4b7f-bddc-f989ac0e9a53.mp4


https://user-images.githubusercontent.com/42477864/228504420-ff93828f-4719-4929-899c-de5d99cc9918.mp4

