### PR TITLE
Remove goron requirement from Zora Hall HP trick

### DIFF
--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -732,7 +732,7 @@
     "Zora Cape Peninsula": "true"
     "Zora Shop": "true"
   locations:
-    "Zora Hall Scrub HP": "has(MASK_ZORA && (trick(MM_ZORA_HALL_HP_NO_DEKU) || (has(MASK_GORON) && has(MASK_DEKU) && has(DEED_MOUNTAIN)))"
+    "Zora Hall Scrub HP": "has(MASK_ZORA) && (trick(MM_ZORA_HALL_HP_NO_DEKU) || (has(MASK_GORON) && has(MASK_DEKU) && has(DEED_MOUNTAIN)))"
     "Zora Hall Scrub Deed": "has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_ZORA)"
     #"Zora Hall Scrub Purchase": "has(MASK_ZORA)"
     "Zora Hall Evan HP": "has(MASK_ZORA) && has_ocarina"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -732,7 +732,7 @@
     "Zora Cape Peninsula": "true"
     "Zora Shop": "true"
   locations:
-    "Zora Hall Scrub HP": "has(MASK_ZORA) && (trick(MM_ZORA_HALL_HP_NO_DEKU) || (has(MASK_GORON) && has(MASK_DEKU) && has(DEED_MOUNTAIN)))"
+    "Zora Hall Scrub HP": "has(MASK_ZORA) && (trick(MM_ZORA_HALL_SCRUB_HP_NO_DEKU) || (has(MASK_GORON) && has(MASK_DEKU) && has(DEED_MOUNTAIN)))"
     "Zora Hall Scrub Deed": "has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_ZORA)"
     #"Zora Hall Scrub Purchase": "has(MASK_ZORA)"
     "Zora Hall Evan HP": "has(MASK_ZORA) && has_ocarina"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -732,7 +732,7 @@
     "Zora Cape Peninsula": "true"
     "Zora Shop": "true"
   locations:
-    "Zora Hall Scrub HP": "(has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_DEKU) && has(MASK_ZORA)) || (trick(MM_ZORA_HALL_SCRUB_HP_GORON) && has(MASK_GORON) && has(MASK_ZORA))"
+    "Zora Hall Scrub HP": "(has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_DEKU) && has(MASK_ZORA)) || (trick(MM_ZORA_HALL_SCRUB_HP_NO_DEKU) && has(MASK_ZORA))"
     "Zora Hall Scrub Deed": "has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_ZORA)"
     #"Zora Hall Scrub Purchase": "has(MASK_ZORA)"
     "Zora Hall Evan HP": "has(MASK_ZORA) && has_ocarina"

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -732,7 +732,7 @@
     "Zora Cape Peninsula": "true"
     "Zora Shop": "true"
   locations:
-    "Zora Hall Scrub HP": "(has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_DEKU) && has(MASK_ZORA)) || (trick(MM_ZORA_HALL_SCRUB_HP_NO_DEKU) && has(MASK_ZORA))"
+    "Zora Hall Scrub HP": "has(MASK_ZORA && (trick(MM_ZORA_HALL_HP_NO_DEKU) || (has(MASK_GORON) && has(MASK_DEKU) && has(DEED_MOUNTAIN)))"
     "Zora Hall Scrub Deed": "has(DEED_MOUNTAIN) && has(MASK_GORON) && has(MASK_ZORA)"
     #"Zora Hall Scrub Purchase": "has(MASK_ZORA)"
     "Zora Hall Evan HP": "has(MASK_ZORA) && has_ocarina"

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -465,7 +465,7 @@ export const TRICKS = {
   MM_KEG_EXPLOSIVES: "Use Powder Kegs as Explosives",
   MM_DOG_RACE_CHEST_NOTHING: "Doggy Racetrack Chest with Nothing",
   MM_SOUTHERN_SWAMP_SCRUB_HP_GORON: "Southern Swamp Scrub HP as Goron",
-  MM_ZORA_HALL_SCRUB_HP_GORON: "Zora Hall Scrub HP as Goron",
+  MM_ZORA_HALL_SCRUB_HP_NO_DEKU: "Zora Hall Scrub HP without Deku",
 };
 
 export type Tricks = {[k in keyof typeof TRICKS]: boolean};


### PR DESCRIPTION
Completely forgot about the zora jump and this supersedes the goron jump as you need zora to get in here anyways.
As such this also renames the trick to Zora Hall Scrub HP without Deku

https://user-images.githubusercontent.com/42477864/228581491-404d92cc-1db0-4419-bea1-36e2fa4bbd02.mp4

