### PR TITLE
MM: Add Pirate Fortress to Dungeon ER

### DIFF
--- a/data/mm/entrances.csv
+++ b/data/mm/entrances.csv
@@ -25,3 +25,5 @@ Ikana Canyon,                       Beneath the Well Entrance,              0x20
 Beneath the Well Entrance,          Ikana Canyon,                           0x9000
 Ikana Valley,                       Secret Shrine Entrance,                 0x20c0
 Secret Shrine Entrance,             Ikana Valley,                           0xba00
+Pirate Fortress,                    Great Bay Coast Fortress,               0x7000
+Great Bay Coast Fortress,           Pirate Fortress,                        0x6850

--- a/data/mm/world/ancient_castle_of_ikana.yml
+++ b/data/mm/world/ancient_castle_of_ikana.yml
@@ -38,8 +38,10 @@
   exits:
     "Ancient Castle of Ikana Interior North 2": "true"
     "Ancient Castle of Ikana Exterior": "true"
+    "Ancient Castle of Ikana Roof Interior": "can_goron_bomb_jump"
   events:
-    IKANA_CASTLE_LIGHT: "has(MASK_DEKU)"
+    IKANA_CASTLE_LIGHT: "has(MASK_DEKU)" #|| (has(MASK_ZORA) && can_gainer) Can press the switch trivially, but can't get back to the roof without these.
+    IKANA_CASTLE_LIGHT2: "can_use_keg"
   locations:
     "Ancient Castle of Ikana HP": "(has(BOW) || can_hookshot_short) && has(MASK_DEKU)"
 "Ancient Castle of Ikana Interior South":
@@ -57,6 +59,7 @@
   exits:
     "Ancient Castle of Ikana Interior": "event(IKANA_CASTLE_LIGHT2)"
     "Ancient Castle of Ikana Wizzrobe": "true"
+    "Ancient Castle of Ikana Roof Exterior": "trick(MM_IKANA_ROOF_PARKOUR)"
   events:
     IKANA_CASTLE_LIGHT2: "can_use_keg"
 "Ancient Castle of Ikana Pre-Boss":

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -244,7 +244,7 @@
     "Road to Southern Swamp": "true"
     "Mountain Village Path Lower": "has(BOW)"
     "Milk Road": "true"
-    "Great Bay Fence": "can_play(SONG_EPONA) || can_goron_bomb_jump"
+    "Great Bay Fence": "can_play(SONG_EPONA) || (can_goron_bomb_jump && has(BOMB_BAG))"
     "Road to Ikana Front": "true"
     "Astral Observatory Balcony": "has(MASK_DEKU) || can_goron_bomb_jump"
   locations:

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -554,12 +554,12 @@
 "Snowhead":
   region: SNOWHEAD
   exits:
-    "Snowhead Entrance": "event(OPEN_SNOWHEAD_TEMPLE)"
+    "Snowhead Entrance": "true"
     "Snowhead Temple": "true"
 "Snowhead Near Great Fairy Fountain":
   region: SNOWHEAD
   exits:
-    "Snowhead Entrance": "event(OPEN_SNOWHEAD_TEMPLE)"
+    "Snowhead Entrance": "true"
     "Snowhead Great Fairy Fountain": "true"
 "Snowhead Great Fairy Fountain":
   region: SNOWHEAD

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -633,8 +633,8 @@
   exits:
     "Fisher's Hut": "true"
     "Great Bay Fence": "true"
-    "Pirate Fortress": "has(MASK_ZORA)"
-    "Pinnacle Rock Entrance": "has(MASK_ZORA)"
+    "Great Bay Coast Fortress": "has(MASK_ZORA)"
+    "Pinnacle Rock Entrance": "true"
     "Laboratory": "true"
     "Zora Cape": "true"
     "Ocean Spider House": "true"
@@ -649,10 +649,11 @@
     "Great Bay Coast Cow Back": "can_hookshot && can_play(SONG_EPONA)"
   gossip:
     "Great Bay Coast Gossip": "true"
-"Great Bay Coast Captured":
+"Great Bay Coast Fortress":
   region: GREAT_BAY_COAST
   exits:
-    "Great Bay Coast": "true"
+    "Great Bay Coast": "has(MASK_ZORA)"
+    "Pirate Fortress": "true"
 "Fisher's Hut":
   region: GREAT_BAY_COAST
   exits:

--- a/data/mm/world/pirate_fortress.yml
+++ b/data/mm/world/pirate_fortress.yml
@@ -1,13 +1,12 @@
 "Pirate Fortress":
-  region: PIRATE_FORTRESS_EXTERIOR
+  dungeon: PF
   exits:
-    "Great Bay Coast": "has(MASK_ZORA)"
+    "Great Bay Coast Fortress": "has(MASK_ZORA)"
     "Pirate Fortress Entrance": "can_reset_time"
 "Pirate Fortress Entrance":
-  region: PIRATE_FORTRESS_EXTERIOR
+  dungeon: PF
   exits:
     "Pirate Fortress": "true"
-    "Great Bay Coast Captured": "true"
     "Pirate Fortress Sewers": "has(MASK_ZORA) && has(MASK_GORON)"
     "Pirate Fortress Entrance Balcony": "can_hookshot || (can_hookshot_short && trick(MM_PFI_BOAT_HOOK))"
     "Pirate Fortress Entrance Lookout": can_hookshot_short && trick(MM_PFI_BOAT_HOOK)
@@ -18,7 +17,7 @@
     "Pirate Fortress Entrance Chest 2": "has(MASK_ZORA)"
     "Pirate Fortress Entrance Chest 3": "has(MASK_ZORA)"
 "Pirate Fortress Entrance Balcony":
-  region: PIRATE_FORTRESS_EXTERIOR
+  dungeon: PF
   exits:
     "Pirate Fortress Entrance": "true"
     "Pirate Fortress Sewers End": "true"
@@ -73,7 +72,7 @@
     "Pirate Fortress Entrance Lookout": "true"
     "Pirate Fortress Barrel Maze": "true"
 "Pirate Fortress Entrance Lookout":
-  region: PIRATE_FORTRESS_EXTERIOR
+  dungeon: PF
   exits:
     "Pirate Fortress Barrel Maze Entry": "true"
     "Pirate Fortress Entrance": "true"
@@ -148,6 +147,6 @@
     "Pirate Fortress Treasure Room Aquarium": "true"
     "Pirate Fortress Interior": "true"
 "Pirate Fortress Entrance Captured":
-  region: PIRATE_FORTRESS_EXTERIOR
+  dungeon: PF
   exits:
     "Pirate Fortress Entrance Balcony": "true"

--- a/include/combo.h
+++ b/include/combo.h
@@ -100,6 +100,7 @@
 #define DUNGEONID_IKANA_CASTLE                      0x13
 #define DUNGEONID_SECRET_SHRINE                     0x14
 #define DUNGEONID_BENEATH_THE_WELL_END              0x15
+#define DUNGEONID_PIRATE_FORTRESS                   0x16
 
 /* MQ IDs */
 #define MQ_DEKU_TREE                0
@@ -159,7 +160,7 @@ typedef struct
     u8              config[0x40];
     ComboDataHints  hints;
     u8              boss[12];
-    u8              dungeons[22];
+    u8              dungeons[23];
     SpecialCond     special[2];
 }
 ComboData;

--- a/lib/combo/logic/entrance.ts
+++ b/lib/combo/logic/entrance.ts
@@ -51,6 +51,7 @@ const DUNGEON_INDEX = {
   ACoI: 19,
   SS: 20,
   BtWE: 21,
+  PF: 22,
 } as {[k: string]: number};;
 
 export class LogicPassEntrances {
@@ -72,7 +73,7 @@ export class LogicPassEntrances {
   private result: EntranceShuffleResult = {
     overrides: {},
     boss: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-    dungeons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+    dungeons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
   };
 
   private isAssignable(src: WorldEntrance, dst: WorldEntrance, overrides: EntranceOverrides, opts?: { mergeStoneTowers?: boolean, ownGame?: boolean }) {
@@ -234,6 +235,9 @@ export class LogicPassEntrances {
     }
     if (this.input.settings.erSpiderHouses) {
       ['SSH', 'OSH'].forEach(d => validDungeons.add(d));
+    }
+    if (this.input.settings.erPirateFortress) {
+      ['PF'].forEach(d => validDungeons.add(d));
     }
     if (this.input.settings.erBeneathWell) {
       ['BtW', 'BtWE'].forEach(d => validDungeons.add(d));

--- a/lib/combo/logic/entrance.ts
+++ b/lib/combo/logic/entrance.ts
@@ -322,7 +322,7 @@ export class LogicPassEntrances {
       ['SSH', 'OSH'].forEach(d => shuffledDungeons.add(d));
     }
     if (this.input.settings.erPirateFortress) {
-      ['PF'].forEach(d => validDungeons.add(d));
+      ['PF'].forEach(d => shuffledDungeons.add(d));
     }
     if (this.input.settings.erBeneathWell) {
       ['BtW', 'BtWE'].forEach(d => shuffledDungeons.add(d));

--- a/lib/combo/logic/world.ts
+++ b/lib/combo/logic/world.ts
@@ -85,6 +85,7 @@ export const DUNGEONS_REGIONS: {[k: string]: string} = {
   ACoI: "MM_IKANA_CASTLE",
   SS: "MM_SECRET_SHRINE",
   BtWE: "MM_BENEATH_THE_WELL",
+  PF: "MM_PIRATE_FORTRESS_EXTERIOR",
 };
 
 const mapExprs = (exprParser: ExprParser, game: Game, char: string, data: any) => {

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -491,6 +491,7 @@ export const TRICKS = {
   MM_MAJORA_LOGIC: "Fight Majora to Reset Time",
   MM_SOUTHERN_SWAMP_SCRUB_HP_GORON: "Southern Swamp Scrub HP as Goron",
   MM_ZORA_HALL_SCRUB_HP_NO_DEKU: "Zora Hall Scrub HP without Deku",
+  MM_IKANA_ROOF_PARKOUR: "Jump from Ikana Castle's Roof Interior to Exterior",
 };
 
 export type Tricks = {[k in keyof typeof TRICKS]: boolean};

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -261,6 +261,12 @@ export const SETTINGS = [{
   type: 'boolean',
   default: false
 }, {
+  key: 'erPirateFortress',
+  name: 'Shuffle Pirate Fortress with Dungeons',
+  category: 'entrances',
+  type: 'boolean',
+  default: false
+}, {
   key: 'erBeneathWell',
   name: 'Shuffle Beneath the Well with Dungeons',
   category: 'entrances',

--- a/src/common/warp.c
+++ b/src/common/warp.c
@@ -155,6 +155,10 @@ void comboTriggerWarp(GameState_Play* play, int bossId)
         isMmEntrance = 1;
         entrance = 0x3400;
         break;
+    case DUNGEONID_PIRATE_FORTRESS:
+        isMmEntrance = 1;
+        entrance = 0x6850;
+        break;
     default:
         UNREACHABLE();
         break;

--- a/tests/seeds/dungeon-boss-er.test.ts
+++ b/tests/seeds/dungeon-boss-er.test.ts
@@ -7,6 +7,7 @@ test("Can make a seed - Dungeon + Boss ER", () => {
     erBoss: 'full',
     erMinorDungeons: true,
     erSpiderHouses: true,
+	  erPirateFortress: true,
 	  erBeneathWell: true,
 	  erIkanaCastle: true,
 	  erSecretShrine: true,


### PR DESCRIPTION
- Adds the option of shuffling the Pirate Fortress Exterior entrance among the dungeons
- Ensures bomb bag for the goron bomb jump to Great Bay Coast to ensure you have a keg for any explosive needs there
- Adds trick for going form Ikana Castle Roof Interior to Exterior