### PR TITLE
Basic overworld ER logic improvements

### DIFF
--- a/data/mm/macros.yml
+++ b/data/mm/macros.yml
@@ -45,3 +45,4 @@
 "trick_sht_fireless": "has_hot_water_distance && trick(MM_SHT_FIRELESS)"
 "can_reset_time": "can_play(SONG_TIME) || (event(MAJORA) && trick(MM_MAJORA_LOGIC))"
 "has_sticks": "event(STICKS) || has(STICK) || has(STICKS_5) || has(STICKS_10) || (setting(sharedNutsSticks) && event(OOT_STICKS))"
+"has_nuts": "event(NUTS) || has(NUT) || has(NUTS_5) || has(NUTS_10) || (setting(sharedNutsSticks) && event(OOT_NUTS))"

--- a/data/mm/world/beneath_the_well.yml
+++ b/data/mm/world/beneath_the_well.yml
@@ -16,16 +16,27 @@
   dungeon: BtW
   exits:
     "Beneath the Well Entrance": "true"
+    "Beneath the Well Middle Section": "has(MASK_GIBDO) && has_bottle"
     "Beneath the Well Sun Block": "event(WELL_BIG_POE) && has_milk"
   events:
     WELL_BIG_POE: "has(MASK_GIBDO) && has_bottle && has(BOMB_BAG) && (has_weapon_range)"
+    STICKS: "true"
   locations:
-    "Beneath the Well Skulltulla Chest": "has(MASK_GIBDO) && has_bottle"
-    "Beneath the Well Cow": "has(MASK_GIBDO) && (event(WELL_HOT_WATER) || has_hot_water_distance) && can_play(SONG_EPONA)"
-"Beneath the Well Sun Block":
+    "Beneath the Well Cow": "has(MASK_GIBDO) && (event(WELL_HOT_WATER) || has_hot_water_distance) && can_play(SONG_EPONA) && has_nuts"
+"Beneath the Well Middle Section":
   dungeon: BtW
   exits:
     "Beneath the Well East Section": "true"
+    "Beneath the Well Sun Block": "event(WELL_BIG_POE) && has_milk"
+  events:
+    STICKS: "true"
+    NUTS: "true"
+  locations:
+    "Beneath the Well Skulltulla Chest": "has(MASK_GIBDO) && has_bottle"
+"Beneath the Well Sun Block":
+  dungeon: BtW
+  exits:
+    "Beneath the Well Middle Section": "true"
     "Beneath the Well End": "has_mirror_shield || can_use_light_arrows"
   locations:
     "Beneath the Well Mirror Shield": "can_use_fire_arrows || event(WELL_BIG_POE)"

--- a/data/mm/world/great_bay_temple.yml
+++ b/data/mm/world/great_bay_temple.yml
@@ -9,7 +9,7 @@
     "Great Bay Temple Entrance": "true"
     "Great Bay Temple Water Wheel": "true"
   locations:
-    "Great Bay Temple Entrance Chest": "true"
+    "Great Bay Temple Entrance Chest": "has_sticks || can_use_fire_arrows"
 "Great Bay Temple Water Wheel":
   dungeon: GB
   events:

--- a/data/mm/world/overworld.yml
+++ b/data/mm/world/overworld.yml
@@ -5,7 +5,16 @@
 "SOARING":
   region: NONE
   exits:
-    "Clock Town": "has(SONG_SOARING) && event(CLOCK_TOWN)"
+    "South Clock Town": "event(CLOCK_TOWN_OWL)"
+    "Milk Road": "event(MILK_ROAD_OWL)"
+    "Swamp Front": "event(SWAMP_OWL)"
+    "Woodfall Shrine": "event(WOODFALL_OWL)"
+    "Mountain Village": "event(MOUNTAIN_VILLAGE_OWL)
+    "Snowhead Entrance": "event(SNOWHEAD_OWL)"
+    "Great Bay Coast": "event(GREAT_BAY_OWL)"
+    "Zora Cape Peninsula": "event(ZORA_CAPE_OWL)"
+    "Ikana Canyon": "event(IKANA_CANYON_OWL)"
+    "Stone Tower Top": "event(STONE_TOWER_OWL)"
 "Oath to Order":
   region: GIANT_DREAM
   locations:
@@ -33,7 +42,7 @@
     "Clock Tower Roof": "true"
   events:
     CLOCK_TOWN_SCRUB: "has(MOON_TEAR)"
-    CLOCK_TOWN_OWL: "can_play(SONG_SOARING)"
+    CLOCK_TOWN_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
   locations:
     "Clock Town South Chest Lower": "can_hookshot || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB)) || trick(MM_SCT_NOTHING) || can_goron_bomb_jump"
     "Clock Town South Chest Upper": "can_hookshot || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB)) || (can_goron_bomb_jump && can_hookshot_short)"
@@ -244,6 +253,7 @@
   region: TERMINA_FIELD
   events:
     STICKS: "true"
+    "NUTS": "true"
   exits:
     "Clock Town South": "true"
     "Clock Town North": "true"
@@ -281,6 +291,9 @@
     "Termina Field Gossip Grotto Rightmost": "true"
 "Road to Southern Swamp":
   region: ROAD_TO_SWAMP
+  events:
+    STICKS: "true"
+    "NUTS": "true"
   exits:
     "Swamp Front": "true"
     "Termina Field": "true"
@@ -308,7 +321,9 @@
   events:
     MAGIC_BEANS_SWAMP: "has(MAGIC_BEAN) && has(MASK_DEKU)"
     FROG_3: "has(MASK_DON_GERO)"
-    SWAMP_OWL: "can_play(SONG_SOARING)"
+    SWAMP_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
+    STICKS: "true"
+    "NUTS": "true"
   locations:
     "Southern Swamp HP": "(has(DEED_LAND) && has(MASK_DEKU)) || (trick(MM_SOUTHERN_SWAMP_SCRUB_HP_GORON) && has(MASK_GORON))"
     "Southern Swamp Scrub Deed": "has(DEED_LAND)"
@@ -317,10 +332,13 @@
     "Southern Swamp Gossip": "true"
 "Swamp Back":
   region: SOUTHERN_SWAMP
+  events:
+    STICKS: "has(MASK_DEKU) || has(MASK_ZORA) || event(CLEAN_SWAMP)"
+    "NUTS": "has(MASK_DEKU) || has(MASK_ZORA) || event(CLEAN_SWAMP)"
   exits:
     "Swamp Front": "event(BOAT_RIDE) || event(CLEAN_SWAMP) || (has(BOW) && (has(MASK_DEKU) || has(MASK_ZORA) || has(MASK_GORON)))"
     "Deku Palace": "true"
-    "Swamp Spider House": "has(MASK_DEKU) || has(MASK_ZORA) || event(CLEAN_SWAMP)"
+    "Swamp Spider House": "(has(MASK_DEKU) || has(MASK_ZORA) || event(CLEAN_SWAMP)) && (has_sticks || has(BOW))"
     "Swamp Canopy Back": "event(CLEAN_SWAMP)"
   locations:
     "Southern Swamp Grotto": "has(MASK_DEKU) || has(MASK_ZORA) || event(CLEAN_SWAMP)"
@@ -340,6 +358,8 @@
     "Swamp Front": "true"
   events:
     KOUME: "has_red_or_blue_potion"
+    STICKS: "true"
+    "NUTS": "true"
   locations:
     "Woods of Mystery Grotto": "true"
     "Swamp Potion Shop Kotake": "true"
@@ -360,6 +380,8 @@
     "Deku Shrine": "event(CLEAN_SWAMP)"
   events:
     MAGIC_BEANS_PALACE: "has(MASK_DEKU) || trick(MM_PALACE_GUARD_SKIP)"
+    STICKS: "has(MASK_DEKU) || event(CLEAN_SWAMP)"
+    "NUTS": "has(MASK_DEKU) || event(CLEAN_SWAMP)"
   locations:
     "Deku Palace HP": "has(MASK_DEKU) || (event(CLEAN_SWAMP) && can_use_beans) || trick(MM_PALACE_GUARD_SKIP)"
     "Deku Palace Grotto Chest": "((has(MASK_DEKU) || trick(MM_PALACE_GUARD_SKIP)) && (can_use_beans || can_hookshot || (can_hookshot_short && trick(MM_SHORT_HOOK_HARD)))) || (event(CLEAN_SWAMP) && can_use_beans)"
@@ -401,8 +423,10 @@
     "Woodfall Near Great Fairy Fountain": "has(MASK_DEKU) || event(CLEAN_SWAMP)"
     "Woodfall Front of Temple": "event(OPEN_WOODFALL_TEMPLE)"
   events:
-    WOODFALL_OWL: "can_play(SONG_SOARING)"
+    WOODFALL_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
     OPEN_WOODFALL_TEMPLE: "has(MASK_DEKU) && can_play(SONG_AWAKENING)"
+    STICKS: "true"
+    "NUTS": "true"
   locations:
     "Woodfall Near Owl Chest": "has(MASK_DEKU) || can_hookshot"
 "Woodfall Near Great Fairy Fountain":
@@ -449,7 +473,9 @@
     "Mountain Village Gossip Outside": "event(BOSS_SNOWHEAD)"
     "Mountain Village Gossip Tunnel": "event(BOSS_SNOWHEAD) && (has(MASK_GORON) || has(MASK_ZORA))"
   events:
-    MOUNTAIN_VILLAGE_OWL: "can_play(SONG_SOARING)"
+    MOUNTAIN_VILLAGE_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
+    STICKS: "event(BOSS_SNOWHEAD) && (has(MASK_GORON) || has(MASK_ZORA))"
+    "NUTS": "event(BOSS_SNOWHEAD) && (has(MASK_GORON) || has(MASK_ZORA))"
   locations:
     "Mountain Village Waterfall Chest": "event(BOSS_SNOWHEAD) && can_use_lens"
     "Mountain Village Don Gero Mask": "event(GORON_FOOD)"
@@ -473,6 +499,8 @@
     "Goron Race": "can_use_keg || event(POWDER_KEG_TRIAL)"
   events:
     TWIN_ISLANDS_HOT_WATER: "(can_use_fire_arrows || event(BOSS_SNOWHEAD) || has_hot_water || has_hot_water_distance) && has_bottle"
+    STICKS: "(has_explosives || trick_keg_explosives || (trick(MM_KEG_EXPLOSIVES) && event(POWDER_KEG_TRIAL))) && (has(MASK_GORON) || scarecrow_hookshot)"
+    NUTS: "(has_explosives || trick_keg_explosives || (trick(MM_KEG_EXPLOSIVES) && event(POWDER_KEG_TRIAL))) && (has(MASK_GORON) || scarecrow_hookshot)"
   locations:
     "Twin Islands Underwater Chest 1": "event(BOSS_SNOWHEAD) && has(MASK_ZORA)"
     "Twin Islands Underwater Chest 2": "event(BOSS_SNOWHEAD) && has(MASK_ZORA)"
@@ -521,6 +549,7 @@
     "Goron Shop": "true"
   events:
     GORON_FOOD: "has(MASK_GORON) && has(MAGIC_UPGRADE) && (can_use_fire_arrows || can_lullaby_half)"
+    STICKS: "true"
   locations:
     "Goron Baby": "has(MASK_GORON) && can_lullaby_half"
 "Goron Shop":
@@ -545,6 +574,9 @@
     "Path to Snowhead HP": "can_use_lens && scarecrow_hookshot"
 "Path to Snowhead Back":
   region: PATH_TO_SNOWHEAD
+  events:
+    STICKS: "has_explosives || trick_keg_explosives"
+    STICKS: "has_explosives || trick_keg_explosives"
   exits:
     "Path to Snowhead Middle": "goron_fast_roll"
     "Snowhead Entrance": "true"
@@ -557,7 +589,7 @@
     "Snowhead": "event(OPEN_SNOWHEAD_TEMPLE)"
     "Snowhead Near Great Fairy Fountain": "event(OPEN_SNOWHEAD_TEMPLE)"
   events:
-    SNOWHEAD_OWL: "can_play(SONG_SOARING)"
+    SNOWHEAD_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
     OPEN_SNOWHEAD_TEMPLE: "can_lullaby || event(BOSS_SNOWHEAD)"
 "Snowhead":
   region: SNOWHEAD
@@ -588,7 +620,7 @@
     "Termina Field": "true"
     "Gorman Track": "true"
   events:
-    MILK_ROAD_OWL: "can_play(SONG_SOARING)"
+    MILK_ROAD_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
   gossip:
     "Milk Road Gossip": "true"
 "Romani Ranch":
@@ -647,7 +679,9 @@
     "Zora Cape": "true"
     "Ocean Spider House": "true"
   events:
-    GREAT_BAY_OWL: "can_play(SONG_SOARING)"
+    GREAT_BAY_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
+    STICKS: "true"
+    NUTS: "true"
   locations:
     "Great Bay Coast Zora Mask": "can_play(SONG_HEALING)"
     "Great Bay Coast HP": "can_use_beans && scarecrow_hookshot"
@@ -692,6 +726,9 @@
     "Laboratory Fish HP": "has_bottle"
 "Zora Cape":
   region: ZORA_CAPE
+  events:
+    STICKS: "can_break_boulders"
+    NUTS: "can_break_boulders"
   exits:
     "Great Bay Coast": "true"
     "Zora Hall Entrance": "has(MASK_ZORA)"
@@ -762,7 +799,7 @@
     "Zora Hall": "true"
     "Great Bay Temple": "has(MASK_ZORA) && can_hookshot && can_play(SONG_ZORA)"
   events:
-    ZORA_CAPE_OWL: "can_play(SONG_SOARING)"
+    ZORA_CAPE_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
 "Gorman Track":
   region: MILK_ROAD
   exits:
@@ -773,6 +810,9 @@
     "Gorman Track Garo Mask": "can_play(SONG_EPONA)"
 "Road to Ikana Front":
   region: ROAD_TO_IKANA
+  events:
+    STICKS: "has(MASK_GORON)"
+    NUTS: "has(MASK_GORON)"
   exits:
     "Termina Field": "true"
     "Road to Ikana Center": "can_play(SONG_EPONA) || (can_goron_bomb_jump && has(BOMB_BAG))"
@@ -791,6 +831,9 @@
     "Road to Ikana Gossip": "true"
 "Ikana Graveyard":
   region: IKANA_GRAVEYARD
+  events:
+    STICKS: "has_explosives || trick_keg_explosives"
+    NUTS: "has_explosives || trick_keg_explosives"
   exits:
     "Road to Ikana Center": "true"
     "Beneath The Graveyard Night 1": "has(MASK_CAPTAIN)"
@@ -805,7 +848,7 @@
     "Ikana Graveyard": "true"
   locations:
     "Beneath The Graveyard Chest": "can_fight || has_explosives || has(BOW) || can_hookshot_short || has(MASK_DEKU)"
-    "Beneath The Graveyard Song of Storms": "can_fight || has_explosives"
+    "Beneath The Graveyard Song of Storms": "(can_fight || has_explosives) && (has_sticks || can_use_fire_arrows)"
 "Beneath The Graveyard Night 2":
   region: IKANA_GRAVEYARD
   exits:
@@ -833,6 +876,8 @@
     "Swamp Front": "true"
   events:
     BLUE_POTION: "has_bottle && has(WALLET)"
+    STICKS: "true"
+    NUTS: "true"
   locations:
     "Ikana Valley Scrub Rupee": "has(DEED_OCEAN) && has(MASK_ZORA)"
     "Ikana Valley Scrub HP": "has(DEED_OCEAN) && has(MASK_ZORA) && has(MASK_DEKU)"
@@ -846,7 +891,7 @@
   exits:
     "Ikana Valley": "true"
   events:
-    SUN_MASK: "true"
+    SUN_MASK: "can_fight || has_explosives || has(BOW)"
 "Ikana Canyon":
   region: IKANA_CANYON
   exits:
@@ -859,7 +904,8 @@
     "Ikana Castle Entrance": "true"
     "Stone Tower": "true"
   events:
-    IKANA_CANYON_OWL: "can_play(SONG_SOARING)"
+    IKANA_CANYON_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
+    NUTS: "true"
   gossip:
     "Ikana Canyon Gossip Upper": "true"
 "Ikana Fairy Fountain":
@@ -911,7 +957,7 @@
     "Stone Tower Front of Temple": "can_use_elegy"
     "Stone Tower Top Inverted": "can_use_elegy && can_use_light_arrows"
   events:
-    STONE_TOWER_OWL: "can_play(SONG_SOARING)"
+    STONE_TOWER_OWL: "has(SONG_SOARING) && (has_sticks || has_weapon)"
 "Stone Tower Front of Temple":
   region: STONE_TOWER
   exits:

--- a/data/mm/world/secret_shrine.yml
+++ b/data/mm/world/secret_shrine.yml
@@ -5,6 +5,8 @@
     "Secret Shrine Main": "can_use_light_arrows && can_reset_time"
 "Secret Shrine Main":
   dungeon: SS
+  events:
+    NUTS: "true"
   exits:
     "Secret Shrine Boss 1": "true"
     "Secret Shrine Boss 2": "true"

--- a/data/mm/world/snowhead_temple.yml
+++ b/data/mm/world/snowhead_temple.yml
@@ -66,7 +66,7 @@
   exits:
     "Snowhead Temple Center Level 1": "true"
   events:
-    SNOWHEAD_RAISE_PILLAR: "has(MASK_GORON)"
+    SNOWHEAD_RAISE_PILLAR: "has(MASK_GORON) && (can_use_fire_arrows || event(SHT_STICK_RUN))"
   locations:
     "Snowhead Temple Pillars Room": "true"
 "Snowhead Temple Center Level 0":
@@ -143,6 +143,8 @@
     "Snowhead Temple Central Room Alcove": "can_use_lens"
 "Snowhead Temple Center Level 3 Iced":
   dungeon: SH
+  events:
+    SHT_STICK_RUN: "has_sticks"
   exits:
     "Snowhead Temple Map Room Upper": "true"
     "Snowhead Temple Center Level 2 Dual": "has_weapon || has(MASK_ZORA) || has(MASK_GORON)"

--- a/data/mm/world/woodfall_temple.yml
+++ b/data/mm/world/woodfall_temple.yml
@@ -20,6 +20,8 @@
     "Woodfall Temple Main Ledge": "event(WOODFALL_TEMPLE_MAIN_FLOWER) || event(WOODFALL_TEMPLE_MAIN_LADDER) || can_hookshot_short"
   events:
     WOODFALL_TEMPLE_MAIN_FLOWER: "can_use_fire_arrows"
+    STICKS: "true"
+    NUTS: "true"
   locations:
     "Woodfall Temple SF Main Pot": "true"
     "Woodfall Temple SF Main Deku Baba": "true"
@@ -42,8 +44,8 @@
   dungeon: WF
   exits:
     "Woodfall Temple Main": "true"
-    "Woodfall Temple Compass Room": "true"
-    "Woodfall Temple Dark Room": "true"
+    "Woodfall Temple Compass Room": "has_sticks || can_use_fire_arrows"
+    "Woodfall Temple Dark Room": "has_sticks || can_use_fire_arrows"
   locations:
     "Woodfall Temple SF Maze Skulltula": "can_fight || has(BOW) || can_use_deku_bubble || has_explosives"
     "Woodfall Temple SF Maze Beehive": "has_weapon_range"
@@ -57,7 +59,7 @@
 "Woodfall Temple Dark Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Maze": "true"
+    "Woodfall Temple Maze": "has_sticks || has(BOW)"
     "Woodfall Temple Pits Room": "true"
   locations:
     "Woodfall Temple Dark Chest": "true"

--- a/data/oot/world/overworld.yml
+++ b/data/oot/world/overworld.yml
@@ -355,15 +355,15 @@
 "Kakariko":
   region: KAKARIKO
   events:
-    KAKARIKO_GATE_OPEN: "is_child && has(ZELDA_LETTER)"
+    KAKARIKO_GATE_OPEN: "(is_child && has(ZELDA_LETTER)) || setting(kakarikoGate, open)"
   exits:
     "Hyrule Field": "true"
-    "Death Mountain": "setting(kakarikoGate, open) || event(KAKARIKO_GATE_OPEN)"
+    "Death Mountain": "event(KAKARIKO_GATE_OPEN)"
     "Graveyard": "true"
     "Bottom of the Well": "is_child && can_play(SONG_STORMS)"
     "Skulltula House": "true"
     "Shooting Gallery Adult": "is_adult"
-    "Kakariko Rooftop": "is_child || can_hookshot"
+    "Kakariko Rooftop": "is_child || can_hookshot || (is_adult && trick(OOT_PASS_COLLISION))"
     "Kakariko Bazaar": "is_adult"
     "Kakariko Potion Shop": "is_adult"
   locations:
@@ -375,7 +375,7 @@
     "Kakariko Song Shadow": "is_adult && has(MEDALLION_FOREST) && has(MEDALLION_FIRE) && has(MEDALLION_WATER)"
     "Kakariko Man on Roof": "can_hookshot || trick(OOT_MAN_ON_ROOF)"
     "Kakariko Potion Shop Odd Potion": "adult_trade(ODD_MUSHROOM)"
-    "Kakariko Grotto Front": "hidden_grotto_bomb"
+    "Kakariko Grotto Front": "hidden_grotto_bomb && (has_weapon || can_use_sticks)"
     "Kakariko Grotto Back": "true"
     "Kakariko GS Roof": "gs_night && can_hookshot"
     "Kakariko GS Shooting Gallery": "gs_night && is_child"
@@ -469,7 +469,7 @@
   exits:
     "Goron City": "true"
     "Dodongo Cavern": "has_bombflowers || is_adult"
-    "Kakariko": "setting(kakarikoGate, open) || event(KAKARIKO_GATE_OPEN)"
+    "Kakariko": "event(KAKARIKO_GATE_OPEN) || trick(OOT_PASS_COLLISION)"
     "Death Mountain Summit": "event(BOULDER_DEATH_MOUNTAIN) || can_ride_bean(BEAN_DEATH_MOUNTAIN)"
   events:
     BEAN_DEATH_MOUNTAIN: "can_use_beans && has_bombflowers"
@@ -633,7 +633,7 @@
     "Lake Hylia Grotto Left Scrub": "can_hit_scrub"
     "Lake Hylia Grotto Center Scrub": "can_hit_scrub"
     "Lake Hylia Grotto Right Scrub": "can_hit_scrub"
-    "Lake Hylia GS Lab Wall": "gs_night && (can_boomerang || (trick(OOT_LAB_WALL_GS) && (has_sword_kokiri || has_sticks)))"
+    "Lake Hylia GS Lab Wall": "gs_night && (can_boomerang || (trick(OOT_LAB_WALL_GS) && (has_sword_kokiri || can_use_sticks)))"
     "Lake Hylia GS Island": "is_child && gs_night && can_damage_skull"
     "Lake Hylia GS Soil": "gs_soil && can_damage_skull"
     "Lake Hylia GS Big Tree": "gs_night && can_longshot"

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -501,6 +501,7 @@ export const TRICKS = {
   OOT_WINDMILL_HP_NOTHING: "Windmill HP as Adult with Nothing",
   OOT_LAB_DIVE_NO_GOLD_SCALE: "Laboratory Dive without Gold Scale",
   OOT_LAB_WALL_GS: "Laboratory Wall GS with Jump Slash",
+  OOT_PASS_COLLISION: "Pass through visible one-way collisions",
   MM_LENS: "Fewer Lens Requirements (MM)",
   MM_PALACE_BEAN_SKIP: "Skip Planting Beans in Deku Palace",
   MM_DARMANI_WALL: "Climb Mountain Village Wall Blind",


### PR DESCRIPTION
- Adds events for MM sticks and nuts wherever they are located, and accounts for having them in logic where needed.
- Makes the SOARING region connect to every owl after having the ability to have struck the owl
- Adds trick for OOT to pass through visible one-way collisions