### PR TITLE
OOT: Add Gerudo Fortress to Region Shuffle

### DIFF
--- a/data/oot/entrances.csv
+++ b/data/oot/entrances.csv
@@ -39,3 +39,5 @@ Lon Lon Ranch,                  Hyrule Field,                     overworld,  0x
 Hyrule Field,                   Lon Lon Ranch,                    overworld,  0x1f9
 Lake Hylia,                     Hyrule Field,                     overworld,  0x102
 Hyrule Field,                   Lake Hylia,                       overworld,  0x189
+Gerudo Fortress Exterior,       Gerudo Valley After Bridge,       overworld,  0x129
+Gerudo Valley After Bridge,     Gerudo Fortress Exterior,         overworld,  0x22d

--- a/lib/combo/settings.ts
+++ b/lib/combo/settings.ts
@@ -439,7 +439,7 @@ export const SETTINGS = [{
   default: false
 }, {
   key: 'erOverworld',
-  name: 'Basic Overworld Shuffle',
+  name: 'Shuffle Major Regions',
   category: 'entrances',
   type: 'boolean',
   default: false


### PR DESCRIPTION
Adds Gerudo Fortress to the region shuffle option and renames the option to reflect what it is.