### PR TITLE
Gerudo Fortress ER Prep

### DIFF
--- a/data/oot/macros.yml
+++ b/data/oot/macros.yml
@@ -59,6 +59,7 @@
 "hidden_grotto_storms": "stone_of_agony && can_play(SONG_STORMS)"
 "has_spiritual_stones": "has(STONE_EMERALD) && has(STONE_RUBY) && has(STONE_SAPPHIRE)"
 #Specific Interaction Macros:
+"can_ride_epona": "is_adult && can_play(SONG_EPONA)"
 "gs_soil": "is_child && has_bottle && (has(BUGS) || event(BUGS))"
 "adult_trade(x)": "is_adult && has(x)"
 "has_blue_fire": "has_bottle && (event(BLUE_FIRE) || has(BLUE_FIRE))"
@@ -70,6 +71,7 @@
 "can_kill_baba_nuts": "has_weapon || has_explosives || can_use_slingshot"
 "can_hit_scrub": "has_nuts || can_hit_triggers_distance || has_shield_for_scrubs || can_collect_distance || can_hammer"
 "has_shield_for_scrubs": "(is_adult && has(SHIELD_HYLIAN)) || (is_child && has(SHIELD_DEKU))"
+"can_rescue_carpenter": "has(SMALL_KEY_GF, 4) && (has_weapon || ((can_boomerang || has_nuts) && can_use_sticks))"
 #Trick Macros
 "gs_night": "is_night && (trick(OOT_NIGHT_GS) || can_play(SONG_SUN))"
 "has_lens": "has_lens_strict || trick(OOT_LENS)"

--- a/data/oot/world/gerudo_fortress.yml
+++ b/data/oot/world/gerudo_fortress.yml
@@ -94,13 +94,13 @@
   dungeon: "GF"
   exits:
     "Gerudo Fortress Lower-Left Ledge": "true"
-    "Gerudo Fortress Break Room Top": "can_hookshot && (can_use_bow || has(GERUDO_CARD))"
+    "Gerudo Fortress Break Room Top": "can_hookshot"
   events:
-    MAGIC: "can_use_bow || has(GERUDO_CARD)"
-    ARROWS: "is_adult && has(GERUDO_CARD)"
+    MAGIC: "can_use_bow || can_hookshot || has(GERUDO_CARD)"
+    ARROWS: "is_adult && (has(GERUDO_CARD) || can_hookshot)"
     SEEDS: "is_child && has(GERUDO_CARD)"
 "Gerudo Fortress Break Room Top":
   dungeon: "GF"
   exits:
     "Gerudo Fortress Above Prison": "true"
-    "Gerudo Fortress Break Room Bottom": "can_hookshot && (can_use_bow || has(GERUDO_CARD))"
+    "Gerudo Fortress Break Room Bottom": "can_hookshot"

--- a/data/oot/world/gerudo_fortress.yml
+++ b/data/oot/world/gerudo_fortress.yml
@@ -1,12 +1,106 @@
-"Gerudo Fortress":
+"Gerudo Fortress Carpenter 1 Left":
   dungeon: "GF"
   exits:
     "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Carpenter 1 Right": "true"
   events:
-    CARPENTERS_RESCUE: "has_weapon && has(SMALL_KEY_GF, 4) && (can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD))"
+    RUPEES: "true"
+    ARROWS: "is_adult"
+    SEEDS: "is_child"
+    CARPENTER_1: can_rescue_carpenter
+    CARPENTERS_RESCUE: "event(CARPENTER_1) && event(CARPENTER_2) && event(CARPENTER_3) && event(CARPENTER_4)"
   locations:
-    "Gerudo Fortress Jail 1": "has_weapon"
-    "Gerudo Fortress Jail 2": "has_weapon"
-    "Gerudo Fortress Jail 3": "has_weapon"
-    "Gerudo Fortress Jail 4": "has_weapon && (can_hookshot || can_use_bow || has_hover_boots || has(GERUDO_CARD))"
+    "Gerudo Fortress Jail 1": "has_weapon || ((can_boomerang || has_nuts) && can_use_sticks)"
     "Gerudo Member Card": "event(CARPENTERS_RESCUE)"
+"Gerudo Fortress Carpenter 1 Right":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Carpenter 1 Left": "true"
+"Gerudo Fortress Carpenter 2 Bottom":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Carpenter 2 Top": "true"
+  events:
+    RUPEES: "true"
+    CARPENTER_2: can_rescue_carpenter
+    CARPENTERS_RESCUE: "event(CARPENTER_1) && event(CARPENTER_2) && event(CARPENTER_3) && event(CARPENTER_4)"
+  locations:
+    "Gerudo Fortress Jail 2": "has_weapon || ((can_boomerang || has_nuts) && can_use_sticks)"
+    "Gerudo Member Card": "event(CARPENTERS_RESCUE)"
+"Gerudo Fortress Carpenter 2 Top":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Lower-Center Ledge": "true"
+    "Gerudo Fortress Carpenter 2 Bottom": "true"
+"Gerudo Fortress Carpenter 3 Bottom":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Lower-Right Ledge": "true"
+    "Gerudo Fortress Carpenter 3 Top": "true"
+"Gerudo Fortress Carpenter 3 Top":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Lower-Center Ledge": "true"
+    "Gerudo Fortress Carpenter 3 Bottom": "true"
+  events:
+    RUPEES: "true"
+    CARPENTER_3: can_rescue_carpenter
+    CARPENTERS_RESCUE: "event(CARPENTER_1) && event(CARPENTER_2) && event(CARPENTER_3) && event(CARPENTER_4)"
+  locations:
+    "Gerudo Fortress Jail 3": "has_weapon || ((can_boomerang || has_nuts) && can_use_sticks)"
+    "Gerudo Member Card": "event(CARPENTERS_RESCUE)"
+"Gerudo Fortress Kitchen Tunnel End":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Kitchen Tunnel Mid": "true"
+"Gerudo Fortress Kitchen Tunnel Mid":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Lower-Right Ledge": "true"
+    "Gerudo Fortress Kitchen Tunnel End": "true"
+    "Gerudo Fortress Kitchen Bottom": "can_use_bow || has(GERUDO_CARD)"
+"Gerudo Fortress Kitchen Bottom":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Kitchen Tunnel Mid": "can_use_bow || has(GERUDO_CARD)"
+    "Gerudo Fortress Kitchen Ledge Near Tunnel": "can_use_bow || has(GERUDO_CARD)"
+    "Gerudo Fortress Kitchen Ledge Away from Tunnel": "can_use_bow || has(GERUDO_CARD)"
+"Gerudo Fortress Kitchen Ledge Near Tunnel":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Lower-Center Ledge": "true"
+    "Gerudo Fortress Kitchen Bottom": "can_use_bow || has(GERUDO_CARD)"
+    "Gerudo Fortress Kitchen Ledge Away from Tunnel": "can_hookshot || has_hover_boots"
+"Gerudo Fortress Kitchen Ledge Away from Tunnel":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Upper-Center Ledge": "true"
+    "Gerudo Fortress Kitchen Bottom": "can_use_bow || has(GERUDO_CARD)"
+    "Gerudo Fortress Kitchen Ledge Near Tunnel": "can_hookshot || has_hover_boots"
+"Gerudo Fortress Carpenter 4":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Center Ledge": "true"
+  events:
+    CARPENTER_4: can_rescue_carpenter
+    CARPENTERS_RESCUE: "event(CARPENTER_1) && event(CARPENTER_2) && event(CARPENTER_3) && event(CARPENTER_4)"
+  locations:
+    "Gerudo Fortress Jail 4": "has_weapon || ((can_boomerang || has_nuts) && can_use_sticks)"
+    "Gerudo Member Card": "event(CARPENTERS_RESCUE)"
+"Gerudo Fortress Break Room Bottom":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Lower-Left Ledge": "true"
+    "Gerudo Fortress Break Room Top": "can_hookshot && (can_use_bow || has(GERUDO_CARD))"
+  events:
+    MAGIC: "can_use_bow || has(GERUDO_CARD)"
+    ARROWS: "is_adult && has(GERUDO_CARD)"
+    SEEDS: "is_child && has(GERUDO_CARD)"
+"Gerudo Fortress Break Room Top":
+  dungeon: "GF"
+  exits:
+    "Gerudo Fortress Above Prison": "true"
+    "Gerudo Fortress Break Room Bottom": "can_hookshot && (can_use_bow || has(GERUDO_CARD))"

--- a/data/oot/world/overworld.yml
+++ b/data/oot/world/overworld.yml
@@ -137,7 +137,7 @@
     "Hyrule Field Grotto Near Kak": "hidden_grotto_bomb"
     "Hyrule Field Fairy Grotto": "has_explosives_or_hammer"
   events:
-    BIG_POE: "event(EPONA) && can_use_bow && has_bottle"
+    BIG_POE: "can_ride_epona && can_use_bow && has_bottle"
     #There are rocks near Gerudo Valley you can farm for drops
     BOMBS: "true"
     RUPEES: "true"
@@ -370,8 +370,9 @@
     "Lon Lon Ranch House": "is_day"
     "Lon Lon Ranch Grotto": "is_child"
   events:
-    EPONA: "is_adult && can_play(SONG_EPONA) && has_rupees && is_day"
-    MALON_COW: "is_adult && event(EPONA) && is_day"
+    #EPONA: "is_adult && can_play(SONG_EPONA) && has_rupees && is_day"
+    EPONA: "true" #If fast Epona becomes a setting, we need a check here... this is "Ingo deposed".
+    MALON_COW: "can_ride_epona && event(EPONA) && is_day"
     RUPEES: "is_child"
   locations:
     "Lon Lon Ranch Malon Song": "is_child && has(OCARINA) && event(MALON) && is_day"
@@ -612,7 +613,8 @@
     "Shooting Gallery Adult": "is_adult && is_day"
     "Kakariko Rooftop": "(is_child && is_day) || can_hookshot || (is_adult && trick(OOT_PASS_COLLISION))"
     "Kakariko Bazaar": "is_adult && is_day"
-    "Kakariko Potion Shop": "is_adult && is_day"
+    "Kakariko Potion Shop": "is_day"
+    "Kakariko Potion Shop Back": "is_adult && is_day"
     "Kakariko Granny Shop": "is_adult"
     "Windmill": "true"
     "Kakariko Carpenter House": "true"
@@ -658,15 +660,21 @@
   region: KAKARIKO
   exits:
     "Kakariko": "is_adult"
+    "Kakariko Potion Shop Back": "is_adult"
   locations:
-    "Kakariko Potion Shop Item 1": "has(WALLET, 1) && has_rupees"
-    "Kakariko Potion Shop Item 2": "has_rupees"
-    "Kakariko Potion Shop Item 3": "has_rupees"
-    "Kakariko Potion Shop Item 4": "has_rupees"
-    "Kakariko Potion Shop Item 5": "has(WALLET, 2) && has_rupees"
-    "Kakariko Potion Shop Item 6": "has_rupees"
-    "Kakariko Potion Shop Item 7": "has_rupees"
-    "Kakariko Potion Shop Item 8": "has_rupees"
+    "Kakariko Potion Shop Item 1": "has(WALLET, 1) && has_rupees && is_adult"
+    "Kakariko Potion Shop Item 2": "has_rupees && is_adult"
+    "Kakariko Potion Shop Item 3": "has_rupees && is_adult"
+    "Kakariko Potion Shop Item 4": "has_rupees && is_adult"
+    "Kakariko Potion Shop Item 5": "has(WALLET, 2) && has_rupees && is_adult"
+    "Kakariko Potion Shop Item 6": "has_rupees && is_adult"
+    "Kakariko Potion Shop Item 7": "has_rupees && is_adult"
+    "Kakariko Potion Shop Item 8": "has_rupees && is_adult"
+"Kakariko Potion Shop Back":
+  region: KAKARIKO
+  exits:
+    "Kakariko": "true"
+    "Kakariko Potion Shop": "true"
 "Kakariko Granny Shop":
   region: KAKARIKO
   exits:
@@ -1233,7 +1241,7 @@
   exits:
     "Lake Hylia": "true"
     "Hyrule Field": "true"
-    "Gerudo Valley After Bridge": "can_longshot || (is_adult && event(EPONA)) || (is_adult && event(CARPENTERS_RESCUE))"
+    "Gerudo Valley After Bridge": "can_longshot || can_ride_epona || (is_adult && event(CARPENTERS_RESCUE))"
     "Octorok Grotto": "can_lift_silver"
   events:
     RUPEES: "true"
@@ -1255,7 +1263,7 @@
   exits:
     "Lake Hylia": "true"
     "Gerudo Fortress Exterior": "true"
-    "Gerudo Valley": "can_longshot || (is_adult && event(EPONA)) || (is_adult && event(CARPENTERS_RESCUE))"
+    "Gerudo Valley": "can_longshot || can_ride_epona || (is_adult && event(CARPENTERS_RESCUE))"
     "Gerudo Valley Storms Grotto": "hidden_grotto_storms && is_adult"
     "Gerudo Valley Tent": "is_adult"
   locations:
@@ -1283,19 +1291,78 @@
 "Gerudo Fortress Exterior":
   region: GERUDO_FORTRESS
   exits:
-    "Gerudo Fortress": "true"
+    "Gerudo Fortress Carpenter 1 Left": "true"
+    "Gerudo Fortress Carpenter 1 Right": "true"
+    "Gerudo Fortress Kitchen Tunnel End": "true"
+    "Gerudo Fortress Carpenter 2 Bottom": "true"
     "Gerudo Valley After Bridge": "true"
     "Fortress Near Wasteland": "event(OPEN_FORTRESS_GATE)"
     "Gerudo Training Grounds": "has(GERUDO_CARD) && is_adult && has_rupees"
     "Gerudo Fortress Grotto": "is_adult && hidden_grotto_storms"
+    "Gerudo Fortress Lower-Right Ledge": "is_child || can_use_bow || has(GERUDO_CARD)"
   events:
     OPEN_FORTRESS_GATE: "has(GERUDO_CARD) && is_adult"
   locations:
-    "Gerudo Fortress Chest": "has_hover_boots || can_longshot || scarecrow_hookshot"
-    "Gerudo Fortress Archery Reward 1": "event(EPONA) && can_use_bow && has(GERUDO_CARD) && has_rupees && is_day"
-    "Gerudo Fortress Archery Reward 2": "event(EPONA) && can_use_bow && has(GERUDO_CARD) && has_rupees && is_day"
-    "Gerudo Fortress GS Wall": "can_hookshot && gs_night"
+    "Gerudo Fortress Archery Reward 1": "can_ride_epona && can_use_bow && has(GERUDO_CARD) && has_rupees && is_day"
+    "Gerudo Fortress Archery Reward 2": "can_ride_epona && can_use_bow && has(GERUDO_CARD) && has_rupees && is_day"
     "Gerudo Fortress GS Target": "can_hookshot && gs_night && has(GERUDO_CARD)"
+"Gerudo Fortress Lower-Right Ledge":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Lower-Center Ledge": "true" #This jump is a little tight as kid, but kid has infinite tries.
+    "Gerudo Fortress Kitchen Tunnel Mid": "true"
+    "Gerudo Fortress Carpenter 3 Bottom": "true"
+"Gerudo Fortress Lower-Center Ledge":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Lower-Right Ledge": "true"
+    "Gerudo Fortress Carpenter 2 Top": "true"
+    "Gerudo Fortress Carpenter 3 Top": "true"
+    "Gerudo Fortress Kitchen Ledge Near Tunnel": "true"
+    "Gerudo Fortress Upper-Right Ledge": "false" #Placeholder for trick jump later
+"Gerudo Fortress Upper-Center Ledge":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Kitchen Ledge Away from Tunnel": "true"
+    "Gerudo Fortress Lower-Center Ledge": "true"
+    "Gerudo Fortress Upper-Right Ledge": "is_adult" #Kid is too short to climb the ledge.
+    "Gerudo Fortress Upper-Left Ledge": "can_longshot"
+    "Gerudo Fortress Center Ledge": "true"
+"Gerudo Fortress Upper-Right Ledge":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Lower-Center Ledge": "true"
+    "Gerudo Fortress Lower-Right Ledge": "true"
+    "Gerudo Fortress Upper-Left Ledge": "scarecrow_hookshot || can_longshot || has_hover_boots"
+    "Gerudo Fortress Center Ledge": "true"
+  locations:
+    "Gerudo Fortress GS Wall": "can_hookshot && gs_night"
+"Gerudo Fortress Upper-Left Ledge":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Lower-Left Ledge": "true"
+    "Gerudo Fortress Center Ledge": "true"
+  locations:
+    "Gerudo Fortress Chest": "true"
+"Gerudo Fortress Center Ledge":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Carpenter 4": "true"
+    "Gerudo Fortress Lower-Center Ledge": "true"
+"Gerudo Fortress Lower-Left Ledge":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Break Room Bottom": "true"
+"Gerudo Fortress Above Prison":
+  region: GERUDO_FORTRESS
+  exits:
+    "Gerudo Fortress Exterior": "true"
+    "Gerudo Fortress Lower-Left Ledge": "true"
+  #locations:
+    #"Gerudo Fortress Unintended PoH": "is_child"
 "Fortress Near Wasteland":
   region: GERUDO_FORTRESS
   exits:
@@ -1304,7 +1371,7 @@
 "Gerudo Fortress Grotto":
   region: GERUDO_FORTRESS
   exits:
-    "Gerudo Fortress": "true"
+    "Gerudo Fortress Exterior": "true"
 "Haunted Wasteland Start":
   region: HAUNTED_WASTELAND
   exits:

--- a/data/oot/world/overworld.yml
+++ b/data/oot/world/overworld.yml
@@ -678,12 +678,12 @@
 "Kakariko Potion Shop Back":
   region: KAKARIKO
   exits:
-    "Kakariko": "true"
+    "Kakariko Back": "is_adult"
     "Kakariko Potion Shop": "true"
 "Kakariko Granny Shop":
   region: KAKARIKO
   exits:
-    "Kakariko": "true"
+    "Kakariko Back": "true"
   events:
     MAGIC: "adult_trade(ODD_MUSHROOM) && has_rupees && has(WALLET) && has_bottle"
   locations:
@@ -741,7 +741,7 @@
 "Kakariko Generic Grotto":
   region: KAKARIKO
   exits:
-    "Kakariko": "true"
+    "Kakariko Back": "true"
   events:
     BOMBS: "can_cut_grass"
     RUPEES: "can_cut_grass"

--- a/data/oot/world/overworld.yml
+++ b/data/oot/world/overworld.yml
@@ -612,15 +612,13 @@
     "Skulltula House": "true"
     "Shooting Gallery Adult": "is_adult && is_day"
     "Kakariko Rooftop": "(is_child && is_day) || can_hookshot || (is_adult && trick(OOT_PASS_COLLISION))"
+    "Kakariko Back": "can_hookshot || has_hover_boots || (is_day && is_child) || (trick(OOT_MAN_ON_ROOF) && (is_adult || can_use_slingshot || has_bombchu))"
     "Kakariko Bazaar": "is_adult && is_day"
     "Kakariko Potion Shop": "is_day"
-    "Kakariko Potion Shop Back": "is_adult && is_day"
-    "Kakariko Granny Shop": "is_adult"
     "Windmill": "true"
     "Kakariko Carpenter House": "true"
     "Impa House Front": "true"
     "ReDead Grotto": "hidden_grotto_bomb"
-    "Kakariko Generic Grotto": "true"
   locations:
     "Kakariko Anju Bottle": "is_child && is_day"
     "Kakariko Anju Egg": "is_adult && is_day"
@@ -643,6 +641,13 @@
   exits:
     "Kakariko": "setting(kakarikoGate, open) || event(KAKARIKO_GATE_OPEN) || is_adult || trick(OOT_PASS_COLLISION)"
     "Death Mountain": "true"
+"Kakariko Back":
+  region: KAKARIKO
+  exits:
+    "Kakariko": "true"
+    "Kakariko Potion Shop Back": "is_adult && is_day"
+    "Kakariko Granny Shop": "is_adult"
+    "Kakariko Generic Grotto": "true"
 "Kakariko Bazaar":
   region: KAKARIKO
   exits:
@@ -1299,7 +1304,7 @@
     "Fortress Near Wasteland": "event(OPEN_FORTRESS_GATE)"
     "Gerudo Training Grounds": "has(GERUDO_CARD) && is_adult && has_rupees"
     "Gerudo Fortress Grotto": "is_adult && hidden_grotto_storms"
-    "Gerudo Fortress Lower-Right Ledge": "is_child || can_use_bow || has(GERUDO_CARD)"
+    "Gerudo Fortress Lower-Right Ledge": "is_child || can_use_bow || can_hookshot || has(GERUDO_CARD)"
   events:
     OPEN_FORTRESS_GATE: "has(GERUDO_CARD) && is_adult"
   locations:


### PR DESCRIPTION
This sets up Gerudo Fortress to be fully robust for entrance randomization. It fixes some issues with the Kakariko Potion Shop for ER as well (that only would have come up with interior shuffle, not yet implemented) and removes Epona's dependency on access to LLR to ride her. Gerudo Fortress is actually a really complex zone so this is kinda a lot, but it's what is necessary to make it randomizable fully. A likely future trick is a certain diagonal jump to skip the kitchen which has a place to insert it (a connection that evaluates to "false", and the unintended PoH in child GF is included commented out just in case we want to add it to the shuffle in the future.